### PR TITLE
Arbitrary borrow count

### DIFF
--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -120,6 +120,7 @@ impl<'id> LCellOwner<'id> {
     }
 }
 
+impl<T> crate::Sealed for LCell<'_, T> {}
 unsafe impl<T> crate::tuple::GenericCell for LCell<'_, T> {
     type Value = T;
 
@@ -128,7 +129,10 @@ unsafe impl<T> crate::tuple::GenericCell for LCell<'_, T> {
     }
 }
 
-pub unsafe trait GenericLCellList<'id> {}
+/// # Safety
+/// 
+/// Must only be implemented for type-lists of &LCell
+pub unsafe trait GenericLCellList<'id>: crate::Sealed {}
 
 unsafe impl GenericLCellList<'_> for crate::tuple::Nil {}
 unsafe impl<'id, T, R> GenericLCellList<'id> for crate::tuple::Cons<&LCell<'id, T>, R>

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -105,6 +105,8 @@ impl<'id> LCellOwner<'id> {
         crate::rw!(self => lc1, lc2, lc3)
     }
 
+    /// This method is not meant to be used directly, use the `qcell::rw` macro instead
+    /// 
     /// Borrow the contents of any number of `LCell` instances mutably.  Panics if
     /// any pair of `LCell` instances point to the same memory.
     #[inline]

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -129,9 +129,11 @@ unsafe impl<T> crate::tuple::GenericCell for LCell<'_, T> {
     }
 }
 
+/// A marker trait that ensures that only `LCells` get accepted for `LCellOwner::rw_generic`
+/// 
 /// # Safety
 /// 
-/// Must only be implemented for type-lists of &LCell
+/// Must only be implemented for type-lists of `&LCell`
 pub unsafe trait GenericLCellList<'id>: crate::Sealed {}
 
 unsafe impl GenericLCellList<'_> for crate::tuple::Nil {}

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -90,7 +90,7 @@ impl<'id> LCellOwner<'id> {
         lc1: &'a LCell<'id, T>,
         lc2: &'a LCell<'id, U>,
     ) -> (&'a mut T, &'a mut U) {
-        crate::rw!(self => *lc1, *lc2)
+        crate::rw!(self => lc1, lc2)
     }
 
     /// Borrow contents of three `LCell` instances mutably.  Panics if
@@ -102,7 +102,7 @@ impl<'id> LCellOwner<'id> {
         lc2: &'a LCell<'id, U>,
         lc3: &'a LCell<'id, V>,
     ) -> (&'a mut T, &'a mut U, &'a mut V) {
-        crate::rw!(self => *lc1, *lc2, *lc3)
+        crate::rw!(self => lc1, lc2, lc3)
     }
 
     /// Borrow the contents of any number of `LCell` instances mutably.  Panics if

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -318,6 +318,11 @@ extern crate lazy_static;
 
 mod macros;
 
+use internal::Sealed;
+mod internal {
+    pub trait Sealed {}
+}
+
 mod lcell;
 mod qcell;
 mod tcell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,7 +323,8 @@ mod qcell;
 mod tcell;
 mod tlcell;
 
-mod tuple;
+#[doc(hidden)]
+pub mod tuple;
 
 pub mod doctest_lcell;
 pub mod doctest_qcell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -316,10 +316,14 @@
 #[macro_use]
 extern crate lazy_static;
 
+mod macros;
+
 mod lcell;
 mod qcell;
 mod tcell;
 mod tlcell;
+
+mod tuple;
 
 pub mod doctest_lcell;
 pub mod doctest_qcell;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -44,9 +44,9 @@ macro_rules! rw {
             rest: $crate::rw!(@tuple $($rest),*)
         }
     };
-    (@destruct [] [$($tup:tt)*] $value:expr) => {{
+    (@destruct [] [$($tup:expr),* $(,)?] $value:expr) => {{
         let $crate::tuple::Nil = $value;
-        ($($tup)*)
+        ($($tup),*)
     }};
     (@destruct [$a:expr $(, $rest:expr)*] [$($tup:tt)*] $value:expr) => {{
         let $crate::tuple::Cons { value, rest } = $value;

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -10,7 +10,7 @@ macro_rules! rw {
     };
     (@tuple $value:expr $(, $rest:expr)*) => {
         $crate::tuple::Cons {
-            value: &$value,
+            value: $value,
             rest: $crate::rw!(@tuple $($rest),*)
         }
     };

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -33,7 +33,7 @@ macro_rules! rw {
     ($owner:expr => $($value:expr),+ $(,)?) => {{
         let output = $owner.rw_generic($crate::rw!(@tuple $($value),*));
 
-        $crate::rw!(@destruct [$($value),*] [] output)
+        $crate::rw! { @destruct [$($value),*] [] output }
     }};
     (@tuple) => {
         $crate::tuple::Nil
@@ -44,13 +44,13 @@ macro_rules! rw {
             rest: $crate::rw!(@tuple $($rest),*)
         }
     };
-    (@destruct [] [$($tup:expr),* $(,)?] $value:expr) => {{
+    (@destruct [] [$($tup:expr),* $(,)?] $value:expr) => {
         let $crate::tuple::Nil = $value;
         ($($tup),*)
-    }};
-    (@destruct [$a:expr $(, $rest:expr)*] [$($tup:tt)*] $value:expr) => {{
+    };
+    (@destruct [$a:expr $(, $rest:expr)*] [$($tup:tt)*] $value:expr) => {
         let $crate::tuple::Cons { value, rest } = $value;
 
-        $crate::rw!(@destruct [$($rest),*] [$($tup)* value,] rest)
-    }};
+        $crate::rw! { @destruct [$($rest),*] [$($tup)* value,] rest }
+    };
 }

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,3 +1,33 @@
+/// A macro to generically uniquely borrow from any number of `*Cell` in this crate
+/// You must pass references to cells directly to this macro, for example `&QCell<i32>`
+/// works, but `&Rc<QCell<i32>>` does not (however you can call `Rc::as_ref` to convert it
+/// to a reference).
+/// 
+/// The macro syntax follows the form
+/// 
+/// ```rust ignore
+/// let owner: QCellOwner;
+/// let cell_1: QCell<_>;
+/// let cell_2: QCell<_>;
+/// let cell_3: QCell<_>;
+/// ...
+/// let cell_n: QCell<_>;
+/// 
+/// let (rw_1, rw_2, rw_3, ..., rw_n) = qcell::rw!(owner => &cell_1, &cell_2, &cell_3, ..., &cell_n);
+/// ```
+/// 
+/// As an example,
+/// 
+/// ```rust
+///# use qcell::{QCell, QCellOwner};
+///# let mut owner = QCellOwner::new();
+///# let c1 = QCell::new(&owner, 100u32);
+///# let c2 = QCell::new(&owner, 200u32);
+/// let (c1mutref, c2mutref) = qcell::rw!(owner => &c1, &c2);
+/// *c1mutref += 1;
+/// *c2mutref += 2;
+/// assert_eq!(303, owner.ro(&c1) + owner.ro(&c2));   // Success!
+/// ```
 #[macro_export]
 macro_rules! rw {
     ($owner:expr => $($value:expr),+ $(,)?) => {{

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -1,0 +1,26 @@
+#[macro_export]
+macro_rules! rw {
+    ($owner:expr => $($value:expr),+ $(,)?) => {{
+        let output = $owner.rw_generic($crate::rw!(@tuple $($value),*));
+
+        $crate::rw!(@destruct [$($value),*] [] output)
+    }};
+    (@tuple) => {
+        $crate::tuple::Nil
+    };
+    (@tuple $value:expr $(, $rest:expr)*) => {
+        $crate::tuple::Cons {
+            value: &$value,
+            rest: $crate::rw!(@tuple $($rest),*)
+        }
+    };
+    (@destruct [] [$($tup:tt)*] $value:expr) => {{
+        let $crate::tuple::Nil = $value;
+        ($($tup)*)
+    }};
+    (@destruct [$a:expr $(, $rest:expr)*] [$($tup:tt)*] $value:expr) => {{
+        let $crate::tuple::Cons { value, rest } = $value;
+
+        $crate::rw!(@destruct [$($rest),*] [$($tup)* value,] rest)
+    }};
+}

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -190,7 +190,7 @@ impl QCellOwner {
     /// another can be borrowed.  Panics if the `QCell` is not owned
     /// by this `QCellOwner`.
     pub fn rw<'a, T>(&'a mut self, qc: &'a QCell<T>) -> &'a mut T {
-        crate::rw!(self => *qc).0
+        crate::rw!(self => qc).0
     }
 
     /// Borrow contents of two `QCell` instances mutably.  Panics if
@@ -201,7 +201,7 @@ impl QCellOwner {
         qc1: &'a QCell<T>,
         qc2: &'a QCell<U>,
     ) -> (&'a mut T, &'a mut U) {
-        crate::rw!(self => *qc1, *qc2)
+        crate::rw!(self => qc1, qc2)
     }
 
     /// Borrow contents of three `QCell` instances mutably.  Panics if
@@ -213,7 +213,7 @@ impl QCellOwner {
         qc2: &'a QCell<U>,
         qc3: &'a QCell<V>,
     ) -> (&'a mut T, &'a mut U, &'a mut V) {
-        crate::rw!(self => *qc1, *qc2, *qc3)
+        crate::rw!(self => qc1, qc2, qc3)
     }
 
     /// Borrow the contents of any number of `LCell` instances mutably.  Panics if

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -233,6 +233,7 @@ impl QCellOwner {
     }
 }
 
+impl<T> crate::Sealed for QCell<T> {}
 unsafe impl<T> crate::tuple::GenericCell for QCell<T> {
     type Value = T;
 
@@ -241,7 +242,10 @@ unsafe impl<T> crate::tuple::GenericCell for QCell<T> {
     }
 }
 
-pub unsafe trait CheckOwner {
+/// # Safety
+/// 
+/// Must only be implemented for type-lists of &QCell
+pub unsafe trait CheckOwner: crate::Sealed {
     fn is_owned_by(&self, owner: OwnerID) -> bool;
 }
 

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -220,6 +220,8 @@ impl QCellOwner {
         crate::rw!(self => qc1, qc2, qc3)
     }
 
+    /// This method is not meant to be used directly, use the `qcell::rw` macro instead
+    /// 
     /// Borrow the contents of any number of `LCell` instances mutably.  Panics if
     /// any pair of `LCell` instances point to the same memory.
     #[inline]

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -151,6 +151,10 @@ impl QCellOwner {
     /// unsafe behaviour once that bug is fixed.  So whilst
     /// strictly-speaking this call is unsafe, in practice there is no
     /// risk unless you really try hard to exploit it.
+    /// 
+    /// # Safety
+    /// 
+    /// You should not use this to create more than `isize::max_value()` QCellOwners
     pub unsafe fn fast_new() -> Self {
         Self {
             // Range 0x80000000 to 0xFFFFFFFF reserved for fast

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -246,9 +246,11 @@ unsafe impl<T> crate::tuple::GenericCell for QCell<T> {
     }
 }
 
+/// Checks if the current `QCell` is owned by the `owner`.
+/// 
 /// # Safety
 /// 
-/// Must only be implemented for type-lists of &QCell
+/// Must only be implemented for type-lists of `&QCell`
 pub unsafe trait CheckOwner: crate::Sealed {
     fn is_owned_by(&self, owner: OwnerID) -> bool;
 }

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -194,7 +194,7 @@ impl QCellOwner {
     /// another can be borrowed.  Panics if the `QCell` is not owned
     /// by this `QCellOwner`.
     pub fn rw<'a, T>(&'a mut self, qc: &'a QCell<T>) -> &'a mut T {
-        crate::rw!(self => qc).0
+        crate::rw!(self => qc)
     }
 
     /// Borrow contents of two `QCell` instances mutably.  Panics if

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -78,7 +78,7 @@ impl<Q: 'static> TCellOwner<Q> {
         tc1: &'a TCell<Q, T>,
         tc2: &'a TCell<Q, U>,
     ) -> (&'a mut T, &'a mut U) {
-        crate::rw!(self => *tc1, *tc2)
+        crate::rw!(self => tc1, tc2)
     }
 
     /// Borrow contents of three `TCell` instances mutably.  Panics if
@@ -90,7 +90,7 @@ impl<Q: 'static> TCellOwner<Q> {
         tc2: &'a TCell<Q, U>,
         tc3: &'a TCell<Q, V>,
     ) -> (&'a mut T, &'a mut U, &'a mut V) {
-        crate::rw!(self => *tc1, *tc2, *tc3)
+        crate::rw!(self => tc1, tc2, tc3)
     }
 
     /// Borrow the contents of any number of `LCell` instances mutably.  Panics if

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -117,9 +117,11 @@ unsafe impl<Q, T> crate::tuple::GenericCell for TCell<Q, T> {
     }
 }
 
+/// A marker trait that ensures that only `TCells` get accepted for `TCellOwner::rw_generic`
+/// 
 /// # Safety
 /// 
-/// Must only be implemented for type-lists of &TCell
+/// Must only be implemented for type-lists of `&TCell`
 pub unsafe trait GenericTCellList<Q>: crate::Sealed {}
 
 unsafe impl<Q> GenericTCellList<Q> for crate::tuple::Nil {}

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -100,7 +100,7 @@ impl<Q: 'static> TCellOwner<Q> {
     where
         T: GenericTCellList<Q> + LoadValues<'a> + ValidateUniqueness
     {
-        assert!(tcells.all_unique(), "Illegal to borrow same LCell multiple times");
+        assert!(tcells.all_unique(), "Illegal to borrow same TCell multiple times");
 
         unsafe {
             tcells.load_values()

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -93,6 +93,8 @@ impl<Q: 'static> TCellOwner<Q> {
         crate::rw!(self => tc1, tc2, tc3)
     }
 
+    /// This method is not meant to be used directly, use the `qcell::rw` macro instead
+    /// 
     /// Borrow the contents of any number of `LCell` instances mutably.  Panics if
     /// any pair of `LCell` instances point to the same memory.
     #[inline]

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -108,6 +108,7 @@ impl<Q: 'static> TCellOwner<Q> {
     }
 }
 
+impl<Q, T> crate::Sealed for TCell<Q, T> {}
 unsafe impl<Q, T> crate::tuple::GenericCell for TCell<Q, T> {
     type Value = T;
 
@@ -116,7 +117,10 @@ unsafe impl<Q, T> crate::tuple::GenericCell for TCell<Q, T> {
     }
 }
 
-pub unsafe trait GenericTCellList<Q> {}
+/// # Safety
+/// 
+/// Must only be implemented for type-lists of &TCell
+pub unsafe trait GenericTCellList<Q>: crate::Sealed {}
 
 unsafe impl<Q> GenericTCellList<Q> for crate::tuple::Nil {}
 unsafe impl<Q, T, R> GenericTCellList<Q> for crate::tuple::Cons<&TCell<Q, T>, R>

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -94,6 +94,8 @@ impl<Q: 'static> TLCellOwner<Q> {
         crate::rw!(self => tc1, tc2, tc3)
     }
 
+    /// This method is not meant to be used directly, use the `qcell::rw` macro instead
+    /// 
     /// Borrow the contents of any number of `LCell` instances mutably.  Panics if
     /// any pair of `LCell` instances point to the same memory.
     #[inline]

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -79,7 +79,7 @@ impl<Q: 'static> TLCellOwner<Q> {
         tc1: &'a TLCell<Q, T>,
         tc2: &'a TLCell<Q, U>,
     ) -> (&'a mut T, &'a mut U) {
-        crate::rw!(self => *tc1, *tc2)
+        crate::rw!(self => tc1, tc2)
     }
 
     /// Borrow contents of three `TLCell` instances mutably.  Panics if
@@ -91,7 +91,7 @@ impl<Q: 'static> TLCellOwner<Q> {
         tc2: &'a TLCell<Q, U>,
         tc3: &'a TLCell<Q, V>,
     ) -> (&'a mut T, &'a mut U, &'a mut V) {
-        crate::rw!(self => *tc1, *tc2, *tc3)
+        crate::rw!(self => tc1, tc2, tc3)
     }
 
     /// Borrow the contents of any number of `LCell` instances mutably.  Panics if

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -118,9 +118,11 @@ unsafe impl<Q, T> crate::tuple::GenericCell for TLCell<Q, T> {
     }
 }
 
+/// A marker trait that ensures that only `TLCells` get accepted for `TLCellOwner::rw_generic`
+/// 
 /// # Safety
 /// 
-/// Must only be implemented for type-lists of &TLCell
+/// Must only be implemented for type-lists of `&TLCell`
 pub unsafe trait GenericTLCellList<Q>: crate::Sealed {}
 
 unsafe impl<Q> GenericTLCellList<Q> for crate::tuple::Nil {}

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -109,6 +109,7 @@ impl<Q: 'static> TLCellOwner<Q> {
     }
 }
 
+impl<Q, T> crate::Sealed for TLCell<Q, T> {}
 unsafe impl<Q, T> crate::tuple::GenericCell for TLCell<Q, T> {
     type Value = T;
 
@@ -117,7 +118,10 @@ unsafe impl<Q, T> crate::tuple::GenericCell for TLCell<Q, T> {
     }
 }
 
-pub unsafe trait GenericTLCellList<Q> {}
+/// # Safety
+/// 
+/// Must only be implemented for type-lists of &TLCell
+pub unsafe trait GenericTLCellList<Q>: crate::Sealed {}
 
 unsafe impl<Q> GenericTLCellList<Q> for crate::tuple::Nil {}
 unsafe impl<Q, T, R> GenericTLCellList<Q> for crate::tuple::Cons<&TLCell<Q, T>, R>

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -101,7 +101,7 @@ impl<Q: 'static> TLCellOwner<Q> {
     where
         T: GenericTLCellList<Q> + LoadValues<'a> + ValidateUniqueness
     {
-        assert!(tcells.all_unique(), "Illegal to borrow same LCell multiple times");
+        assert!(tcells.all_unique(), "Illegal to borrow same TLCell multiple times");
 
         unsafe {
             tcells.load_values()

--- a/src/tuple.rs
+++ b/src/tuple.rs
@@ -1,0 +1,98 @@
+
+pub struct Nil;
+
+#[derive(Clone, Copy)]
+pub struct Cons<T, R> {
+    pub value: T,
+    pub rest: R
+}
+
+pub unsafe trait GenericCell {
+    type Value;
+
+    fn rw_ptr(&self) -> *mut Self::Value;
+}
+
+pub unsafe trait IterAddresses {
+    type Iter: Iterator<Item = usize>;
+
+    fn iter_addr(&self) -> Self::Iter;
+}
+
+unsafe impl IterAddresses for Nil {
+    type Iter = std::iter::Empty<usize>;
+
+    #[inline]
+    fn iter_addr(&self) -> Self::Iter {
+        std::iter::empty()
+    }
+}
+
+unsafe impl<T, R> IterAddresses for Cons<&T, R>
+where
+    R: IterAddresses
+{
+    type Iter = std::iter::Chain<std::iter::Once<usize>, R::Iter>;
+
+    #[inline]
+    fn iter_addr(&self) -> Self::Iter {
+        std::iter::once(self.value as *const _ as usize).chain(self.rest.iter_addr())
+    }
+}
+
+pub unsafe trait ValidateUniqueness {
+    fn all_unique(&self) -> bool;
+}
+
+// nil is trivially unique
+unsafe impl ValidateUniqueness for Nil {
+    #[inline]
+    fn all_unique(&self) -> bool { true }
+}
+
+// Cons is unique if the rest of the list is unique, 
+// and if the current address is not the same as any other address
+unsafe impl<T, R> ValidateUniqueness for Cons<&T, R>
+where
+    R: IterAddresses + ValidateUniqueness
+{
+    #[inline]
+    fn all_unique(&self) -> bool {
+        if self.rest.all_unique() {
+            let addr = self.value as *const _ as usize;
+
+            self.rest.iter_addr().all(move |a| a != addr)
+        } else {
+            false
+        }
+    }
+}
+
+pub unsafe trait LoadValues<'a> {
+    type Output;
+
+    unsafe fn load_values(self) -> Self::Output;
+}
+
+unsafe impl LoadValues<'_> for Nil {
+    type Output = Self;
+
+    #[inline]
+    unsafe fn load_values(self) -> Self::Output { Self }
+}
+
+unsafe impl<'a, T, R> LoadValues<'a> for Cons<&'a T, R>
+where
+    T: GenericCell,
+    R: LoadValues<'a>
+{
+    type Output = Cons<&'a mut T::Value, R::Output>;
+
+    #[inline]
+    unsafe fn load_values(self) -> Self::Output {
+        Cons {
+            value: &mut *self.value.rw_ptr(),
+            rest: self.rest.load_values()
+        }
+    }
+}


### PR DESCRIPTION
This allows you to borrow as many `rw` borrows as you want. (remove the limitation of 3)