### PR TITLE
added a few extra bits of functionality

### DIFF
--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -152,7 +152,7 @@ impl<'id, T> LCell<'id, T> {
     /// # Safety
     /// 
     /// It is only safe to write to this pointer while the cell is
-    /// not being held by a `ro` lock.
+    /// not being held by a `ro` or `rw` lock.
     #[inline]
     pub const fn as_ptr(&self) -> *mut T {
         self.value.get()

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -146,6 +146,17 @@ impl<'id, T> LCell<'id, T> {
             value: UnsafeCell::new(value),
         }
     }
+
+    /// Get a pointer into the cell
+    /// 
+    /// # Safety
+    /// 
+    /// It is only safe to write to this pointer while the cell is
+    /// not being held by a `ro` lock.
+    #[inline]
+    pub const fn as_ptr(&self) -> *mut T {
+        self.value.get()
+    }
 }
 
 // LCellOwner and LCell already automatically implement Send, but not

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -306,6 +306,21 @@ mod tests {
         // Cargo.toml.  So use a lock instead.
         static ref LOCK: Mutex<()> = Mutex::new(());
     }
+
+    #[test]
+    fn qcell_owner() {
+        let _lock = LOCK.lock().unwrap();
+        let owner = QCellOwner::new();
+        let other = QCellOwner::new();
+        let c1 = QCell::new(&owner, 100u32);
+        let c2 = QCell::new(&other, 200u32);
+        
+        assert!(owner.owns(&c1));
+        assert!(!owner.owns(&c2));
+        assert!(!other.owns(&c1));
+        assert!(other.owns(&c2));
+    }
+
     #[test]
     fn qcell() {
         let _lock = LOCK.lock().unwrap();

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -158,6 +158,11 @@ impl QCellOwner {
         }
     }
 
+    /// Check if `self` owns the given `QCell<T>`
+    pub const fn owns<T>(&self, cell: &QCell<T>) -> bool {
+        self.id == cell.owner
+    }
+
     /// Create a new cell owned by this owner instance.  See also
     /// [`QCell::new`].
     ///
@@ -277,6 +282,17 @@ impl<T> QCell<T> {
             value: UnsafeCell::new(value),
             owner: owner.id,
         }
+    }
+
+    /// Get a pointer into the cell
+    /// 
+    /// # Safety
+    /// 
+    /// It is only safe to write to this pointer while the cell is
+    /// not being held by a `ro` lock.
+    #[inline]
+    pub const fn as_ptr(&self) -> *mut T {
+        self.value.get()
     }
 }
 

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -289,7 +289,7 @@ impl<T> QCell<T> {
     /// # Safety
     /// 
     /// It is only safe to write to this pointer while the cell is
-    /// not being held by a `ro` lock.
+    /// not being held by a `ro` or `rw` lock.
     #[inline]
     pub const fn as_ptr(&self) -> *mut T {
         self.value.get()

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -134,6 +134,17 @@ impl<Q, T> TCell<Q, T> {
             value: UnsafeCell::new(value),
         }
     }
+
+    /// Get a pointer into the cell
+    /// 
+    /// # Safety
+    /// 
+    /// It is only safe to write to this pointer while the cell is
+    /// not being held by a `ro` lock.
+    #[inline]
+    pub const fn as_ptr(&self) -> *mut T {
+        self.value.get()
+    }
 }
 
 // It's fine to Send a TCell to a different thread if the containted

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -140,7 +140,7 @@ impl<Q, T> TCell<Q, T> {
     /// # Safety
     /// 
     /// It is only safe to write to this pointer while the cell is
-    /// not being held by a `ro` lock.
+    /// not being held by a `ro` or `rw` lock.
     #[inline]
     pub const fn as_ptr(&self) -> *mut T {
         self.value.get()

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -144,7 +144,7 @@ impl<Q, T> TLCell<Q, T> {
     /// # Safety
     /// 
     /// It is only safe to write to this pointer while the cell is
-    /// not being held by a `ro` lock.
+    /// not being held by a `ro` or `rw` lock.
     #[inline]
     pub const fn as_ptr(&self) -> *mut T {
         self.value.get()

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -138,6 +138,17 @@ impl<Q, T> TLCell<Q, T> {
             value: UnsafeCell::new(value),
         }
     }
+
+    /// Get a pointer into the cell
+    /// 
+    /// # Safety
+    /// 
+    /// It is only safe to write to this pointer while the cell is
+    /// not being held by a `ro` lock.
+    #[inline]
+    pub const fn as_ptr(&self) -> *mut T {
+        self.value.get()
+    }
 }
 
 // TLCell absolutely cannot be Sync, since otherwise you could send


### PR DESCRIPTION
This allows other crates to build unsafe abstractoins
on top of these cells

These are the bits of functionality that I talked about in #9 [here](https://github.com/uazu/qcell/pull/9#issuecomment-568816507)

I'm a bit unsure about the documentation, and I don't think these warrant tests besides `QCellOwner::owns`