### PR TITLE
Fix soundness issues with covariant `Q` argument

### DIFF
--- a/src/compiletest/tcell-14.stderr
+++ b/src/compiletest/tcell-14.stderr
@@ -6,5 +6,6 @@ error[E0277]: `Rc<()>` cannot be sent between threads safely
 9 |     is_send::<TCell<Marker, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
-  = help: the trait `Send` is not implemented for `Rc<()>`
-  = note: required because of the requirements on the impl of `Send` for `TCell<Marker, Rc<()>>`
+  = help: within `TCell<Marker, Rc<()>>`, the trait `Send` is not implemented for `Rc<()>`
+  = note: required because it appears within the type `UnsafeCell<Rc<()>>`
+  = note: required because it appears within the type `TCell<Marker, Rc<()>>`

--- a/src/compiletest/tcell-15.stderr
+++ b/src/compiletest/tcell-15.stderr
@@ -1,14 +1,20 @@
 error[E0277]: `Rc<i32>` cannot be sent between threads safely
    --> $DIR/tcell-15.rs:15:5
     |
-15  |     std::thread::spawn(move || {    // Compile fail
-    |     ^^^^^^^^^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
+15  |       std::thread::spawn(move || {    // Compile fail
+    |  _____^^^^^^^^^^^^^^^^^^_-
+    | |     |
+    | |     `Rc<i32>` cannot be sent between threads safely
+16  | |         assert_eq!(100, **owner.ro(&cell));
+17  | |     }).join();
+    | |_____- within this `[closure@$DIR/src/compiletest/tcell-15.rs:15:24: 17:6]`
     |
    ::: $RUST/std/src/thread/mod.rs
     |
-    |     F: Send + 'static,
-    |        ---- required by this bound in `spawn`
+    |       F: Send + 'static,
+    |          ---- required by this bound in `spawn`
     |
-    = help: the trait `Send` is not implemented for `Rc<i32>`
-    = note: required because of the requirements on the impl of `Send` for `TCell<Marker, Rc<i32>>`
+    = help: within `[closure@$DIR/src/compiletest/tcell-15.rs:15:24: 17:6]`, the trait `Send` is not implemented for `Rc<i32>`
+    = note: required because it appears within the type `UnsafeCell<Rc<i32>>`
+    = note: required because it appears within the type `TCell<Marker, Rc<i32>>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tcell-15.rs:15:24: 17:6]`

--- a/src/compiletest/tlcell-10.stderr
+++ b/src/compiletest/tlcell-10.stderr
@@ -7,6 +7,6 @@ error[E0277]: `*const ()` cannot be sent between threads safely
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
   |
   = help: within `TLCellOwner<Marker>`, the trait `Send` is not implemented for `*const ()`
-  = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
-  = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
+  = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
+  = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
   = note: required because it appears within the type `TLCellOwner<Marker>`

--- a/src/compiletest/tlcell-10.stderr
+++ b/src/compiletest/tlcell-10.stderr
@@ -1,11 +1,12 @@
-error[E0277]: `*const Marker` cannot be sent between threads safely
+error[E0277]: `*const ()` cannot be sent between threads safely
  --> $DIR/tlcell-10.rs:8:5
   |
 7 |     fn is_send<T: Send>() {}
   |                   ---- required by this bound in `is_send`
 8 |     is_send::<TLCellOwner<Marker>>();  // Compile fail
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const Marker` cannot be sent between threads safely
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
   |
-  = help: within `TLCellOwner<Marker>`, the trait `Send` is not implemented for `*const Marker`
-  = note: required because it appears within the type `PhantomData<*const Marker>`
+  = help: within `TLCellOwner<Marker>`, the trait `Send` is not implemented for `*const ()`
+  = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
+  = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
   = note: required because it appears within the type `TLCellOwner<Marker>`

--- a/src/compiletest/tlcell-11.stderr
+++ b/src/compiletest/tlcell-11.stderr
@@ -7,6 +7,6 @@ error[E0277]: `*const ()` cannot be shared between threads safely
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be shared between threads safely
   |
   = help: within `TLCellOwner<Marker>`, the trait `Sync` is not implemented for `*const ()`
-  = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
-  = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
+  = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
+  = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
   = note: required because it appears within the type `TLCellOwner<Marker>`

--- a/src/compiletest/tlcell-11.stderr
+++ b/src/compiletest/tlcell-11.stderr
@@ -1,11 +1,12 @@
-error[E0277]: `*const Marker` cannot be shared between threads safely
+error[E0277]: `*const ()` cannot be shared between threads safely
  --> $DIR/tlcell-11.rs:8:5
   |
 7 |     fn is_sync<T: Sync>() {}
   |                   ---- required by this bound in `is_sync`
 8 |     is_sync::<TLCellOwner<Marker>>();  // Compile fail
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const Marker` cannot be shared between threads safely
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be shared between threads safely
   |
-  = help: within `TLCellOwner<Marker>`, the trait `Sync` is not implemented for `*const Marker`
-  = note: required because it appears within the type `PhantomData<*const Marker>`
+  = help: within `TLCellOwner<Marker>`, the trait `Sync` is not implemented for `*const ()`
+  = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
+  = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
   = note: required because it appears within the type `TLCellOwner<Marker>`

--- a/src/compiletest/tlcell-12.stderr
+++ b/src/compiletest/tlcell-12.stderr
@@ -18,6 +18,6 @@ error[E0277]: `*const ()` cannot be shared between threads safely
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be shared between threads safely
   |
   = help: within `TLCell<Marker, ()>`, the trait `Sync` is not implemented for `*const ()`
-  = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
-  = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
+  = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
+  = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
   = note: required because it appears within the type `TLCell<Marker, ()>`

--- a/src/compiletest/tlcell-12.stderr
+++ b/src/compiletest/tlcell-12.stderr
@@ -9,14 +9,15 @@ error[E0277]: `UnsafeCell<()>` cannot be shared between threads safely
   = help: within `TLCell<Marker, ()>`, the trait `Sync` is not implemented for `UnsafeCell<()>`
   = note: required because it appears within the type `TLCell<Marker, ()>`
 
-error[E0277]: `*const Marker` cannot be shared between threads safely
+error[E0277]: `*const ()` cannot be shared between threads safely
  --> $DIR/tlcell-12.rs:8:5
   |
 7 |     fn is_sync<T: Sync>() {}
   |                   ---- required by this bound in `is_sync`
 8 |     is_sync::<TLCell<Marker, ()>>(); // Compile fail
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const Marker` cannot be shared between threads safely
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be shared between threads safely
   |
-  = help: within `TLCell<Marker, ()>`, the trait `Sync` is not implemented for `*const Marker`
-  = note: required because it appears within the type `PhantomData<*const Marker>`
+  = help: within `TLCell<Marker, ()>`, the trait `Sync` is not implemented for `*const ()`
+  = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
+  = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
   = note: required because it appears within the type `TLCell<Marker, ()>`

--- a/src/compiletest/tlcell-12.stderr
+++ b/src/compiletest/tlcell-12.stderr
@@ -8,16 +8,3 @@ error[E0277]: `UnsafeCell<()>` cannot be shared between threads safely
   |
   = help: within `TLCell<Marker, ()>`, the trait `Sync` is not implemented for `UnsafeCell<()>`
   = note: required because it appears within the type `TLCell<Marker, ()>`
-
-error[E0277]: `*const ()` cannot be shared between threads safely
- --> $DIR/tlcell-12.rs:8:5
-  |
-7 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
-8 |     is_sync::<TLCell<Marker, ()>>(); // Compile fail
-  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be shared between threads safely
-  |
-  = help: within `TLCell<Marker, ()>`, the trait `Sync` is not implemented for `*const ()`
-  = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
-  = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
-  = note: required because it appears within the type `TLCell<Marker, ()>`

--- a/src/compiletest/tlcell-13.stderr
+++ b/src/compiletest/tlcell-13.stderr
@@ -1,10 +1,10 @@
-error[E0277]: `*const Marker` cannot be sent between threads safely
+error[E0277]: `*const ()` cannot be sent between threads safely
    --> $DIR/tlcell-13.rs:12:5
     |
 12  |       std::thread::spawn(move || {
     |  _____^^^^^^^^^^^^^^^^^^_-
     | |     |
-    | |     `*const Marker` cannot be sent between threads safely
+    | |     `*const ()` cannot be sent between threads safely
 13  | |         assert_eq!(*owner.ro(&cell), 100);
 14  | |     }).join();
     | |_____- within this `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`
@@ -14,7 +14,8 @@ error[E0277]: `*const Marker` cannot be sent between threads safely
     |       F: Send + 'static,
     |          ---- required by this bound in `spawn`
     |
-    = help: within `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`, the trait `Send` is not implemented for `*const Marker`
-    = note: required because it appears within the type `PhantomData<*const Marker>`
+    = help: within `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`, the trait `Send` is not implemented for `*const ()`
+    = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
+    = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
     = note: required because it appears within the type `TLCellOwner<Marker>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`

--- a/src/compiletest/tlcell-13.stderr
+++ b/src/compiletest/tlcell-13.stderr
@@ -15,7 +15,7 @@ error[E0277]: `*const ()` cannot be sent between threads safely
     |          ---- required by this bound in `spawn`
     |
     = help: within `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`, the trait `Send` is not implemented for `*const ()`
-    = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
-    = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
+    = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
+    = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
     = note: required because it appears within the type `TLCellOwner<Marker>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`

--- a/src/compiletest/tlcell-14.stderr
+++ b/src/compiletest/tlcell-14.stderr
@@ -6,5 +6,6 @@ error[E0277]: `Rc<()>` cannot be sent between threads safely
 9 |     is_send::<TLCell<Marker, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
-  = help: the trait `Send` is not implemented for `Rc<()>`
-  = note: required because of the requirements on the impl of `Send` for `TLCell<Marker, Rc<()>>`
+  = help: within `TLCell<Marker, Rc<()>>`, the trait `Send` is not implemented for `Rc<()>`
+  = note: required because it appears within the type `UnsafeCell<Rc<()>>`
+  = note: required because it appears within the type `TLCell<Marker, Rc<()>>`

--- a/src/compiletest/tlcell-15.stderr
+++ b/src/compiletest/tlcell-15.stderr
@@ -13,13 +13,13 @@ error[E0277]: `Rc<i32>` cannot be sent between threads safely
     = note: required because of the requirements on the impl of `Send` for `TLCell<Marker, Rc<i32>>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`
 
-error[E0277]: `*const Marker` cannot be sent between threads safely
+error[E0277]: `*const ()` cannot be sent between threads safely
    --> $DIR/tlcell-15.rs:15:5
     |
 15  |       std::thread::spawn(move || {    // Compile fail
     |  _____^^^^^^^^^^^^^^^^^^_-
     | |     |
-    | |     `*const Marker` cannot be sent between threads safely
+    | |     `*const ()` cannot be sent between threads safely
 16  | |         assert_eq!(100, **owner.ro(&cell));
 17  | |     }).join();
     | |_____- within this `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`
@@ -29,7 +29,8 @@ error[E0277]: `*const Marker` cannot be sent between threads safely
     |       F: Send + 'static,
     |          ---- required by this bound in `spawn`
     |
-    = help: within `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`, the trait `Send` is not implemented for `*const Marker`
-    = note: required because it appears within the type `PhantomData<*const Marker>`
+    = help: within `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`, the trait `Send` is not implemented for `*const ()`
+    = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
+    = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
     = note: required because it appears within the type `TLCellOwner<Marker>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`

--- a/src/compiletest/tlcell-15.stderr
+++ b/src/compiletest/tlcell-15.stderr
@@ -1,16 +1,22 @@
 error[E0277]: `Rc<i32>` cannot be sent between threads safely
    --> $DIR/tlcell-15.rs:15:5
     |
-15  |     std::thread::spawn(move || {    // Compile fail
-    |     ^^^^^^^^^^^^^^^^^^ `Rc<i32>` cannot be sent between threads safely
+15  |       std::thread::spawn(move || {    // Compile fail
+    |  _____^^^^^^^^^^^^^^^^^^_-
+    | |     |
+    | |     `Rc<i32>` cannot be sent between threads safely
+16  | |         assert_eq!(100, **owner.ro(&cell));
+17  | |     }).join();
+    | |_____- within this `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`
     |
    ::: $RUST/std/src/thread/mod.rs
     |
-    |     F: Send + 'static,
-    |        ---- required by this bound in `spawn`
+    |       F: Send + 'static,
+    |          ---- required by this bound in `spawn`
     |
-    = help: the trait `Send` is not implemented for `Rc<i32>`
-    = note: required because of the requirements on the impl of `Send` for `TLCell<Marker, Rc<i32>>`
+    = help: within `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`, the trait `Send` is not implemented for `Rc<i32>`
+    = note: required because it appears within the type `UnsafeCell<Rc<i32>>`
+    = note: required because it appears within the type `TLCell<Marker, Rc<i32>>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`
 
 error[E0277]: `*const ()` cannot be sent between threads safely

--- a/src/compiletest/tlcell-15.stderr
+++ b/src/compiletest/tlcell-15.stderr
@@ -30,7 +30,7 @@ error[E0277]: `*const ()` cannot be sent between threads safely
     |          ---- required by this bound in `spawn`
     |
     = help: within `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`, the trait `Send` is not implemented for `*const ()`
-    = note: required because it appears within the type `(*const (), qcell::Invariant<Marker>)`
-    = note: required because it appears within the type `PhantomData<(*const (), qcell::Invariant<Marker>)>`
+    = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
+    = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
     = note: required because it appears within the type `TLCellOwner<Marker>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`

--- a/src/doctest_tcell.rs
+++ b/src/doctest_tcell.rs
@@ -14,9 +14,9 @@
 //! let mut owner1 = ACellOwner::new();
 //! let mut owner2 = ACellOwner::new();  // Panics here
 //! ```
-//! 
+//!
 //! You can test if another owner exists using `TCellOwner::try_new()`:
-//! 
+//!
 //! ```
 //!# use qcell::{TCell, TCellOwner};
 //!# use std::rc::Rc;

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -1,7 +1,8 @@
 use std::cell::{Cell, UnsafeCell};
 use std::marker::PhantomData;
+struct Invariant<Q>(fn(Q) -> Q);
 
-type Id<'id> = PhantomData<Cell<&'id mut ()>>;
+type Id<'id> = PhantomData<Invariant<&'id ()>>;
 
 /// Borrowing-owner of zero or more [`LCell`](struct.LCell.html)
 /// instances.
@@ -169,7 +170,7 @@ impl<'id, T: ?Sized> LCell<'id, T> {
     }
 }
 
-// LCellOwner and LCell already automatically implement Send, but not
+// LCell already automatically implements Send, but not
 // Sync. We can add these implementations though, since it's fine to
 // send a &LCell to another thread, and even mutably borrow the value
 // there, as long as T is Send and Sync.
@@ -185,7 +186,6 @@ impl<'id, T: ?Sized> LCell<'id, T> {
 // as those of std::sync::RwLock<T>. That's not a coincidence.
 // The way these types let you access T concurrently is the same,
 // even though the locking mechanisms are different.
-unsafe impl<'id> Sync for LCellOwner<'id> {}
 unsafe impl<'id, T: Send + Sync + ?Sized> Sync for LCell<'id, T> {}
 
 #[cfg(test)]

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -1,7 +1,7 @@
 use std::cell::{Cell, UnsafeCell};
 use std::marker::PhantomData;
-struct Invariant<Q>(fn(Q) -> Q);
 
+use super::Invariant;
 type Id<'id> = PhantomData<Invariant<&'id ()>>;
 
 /// Borrowing-owner of zero or more [`LCell`](struct.LCell.html)

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -1,4 +1,4 @@
-use std::cell::{Cell, UnsafeCell};
+use std::cell::UnsafeCell;
 use std::marker::PhantomData;
 
 use super::Invariant;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,10 +116,10 @@
 //!# use qcell::{LCell, LCellOwner};
 //!# use std::rc::Rc;
 //! LCellOwner::scope(|mut owner| {
-//!   let item = Rc::new(LCell::new(Vec::<u8>::new()));
-//!   let iref = owner.rw(&item);
-//!   iref.push(1);
-//!   test(&mut owner, &item);
+//!     let item = Rc::new(LCell::new(Vec::<u8>::new()));
+//!     let iref = owner.rw(&item);
+//!     iref.push(1);
+//!     test(&mut owner, &item);
 //! });
 //!
 //! fn test<'id>(owner: &mut LCellOwner<'id>, item: &Rc<LCell<'id, Vec<u8>>>) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -323,6 +323,11 @@ pub mod doctest_qcell;
 pub mod doctest_tcell;
 pub mod doctest_tlcell;
 
+// Used in lcell, tcell, tlcell.
+// Needs an abstraction as a struct, since otherwise we'll get errors
+// regarding "function pointers cannot appear in constant functions"
+struct Invariant<T>(fn(T) -> T);
+
 pub use crate::lcell::LCell;
 pub use crate::lcell::LCellOwner;
 pub use crate::qcell::QCell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -355,7 +355,7 @@ pub use crate::tlcell::TLCellOwner;
 // all is okay, check in the changes.
 #[cfg(test)]
 pub mod compiletest {
-    #[rustversion::all(stable, since(1.54), before(1.55))]
+    #[rustversion::all(stable, since(1.55), before(1.56))]
     #[test]
     fn ui() {
         let t = trybuild::TestCases::new();

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -176,10 +176,8 @@ impl<Q: 'static> TCellOwner<Q> {
 ///
 /// [`TCellOwner`]: struct.TCellOwner.html
 pub struct TCell<Q, T: ?Sized> {
-    // Use *const () to disable Send and Sync, which are then re-enabled
-    // below under certain conditions,
     // use Invariant<Q> for invariant parameter, not influencing
-    // other auto-traits like UnwindSafe
+    // other auto-traits, e.g. UnwindSafe (unlike other solutions like `*mut Q` or `Cell<Q>`)
     owner: PhantomData<Invariant<Q>>,
     // Disables `Sync`, gives the right `Send` implementation.
     // `Sync` is re-enabled below under certain conditions.

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -179,7 +179,11 @@ pub struct TCell<Q, T: ?Sized> {
     // use Invariant<Q> for invariant parameter, not influencing
     // other auto-traits, e.g. UnwindSafe (unlike other solutions like `*mut Q` or `Cell<Q>`)
     owner: PhantomData<Invariant<Q>>,
-    // Also disables `Sync`, gives the right `Send` implementation.
+    // It's fine to Send a TCell to a different thread if the containted
+    // type is Send, because you can only send something if nothing
+    // borrows it, so nothing can be accessing its contents.
+    //
+    // `UnsafeCell` disables `Sync` and already gives the right `Send` implementation.
     // `Sync` is re-enabled below under certain conditions.
     value: UnsafeCell<T>,
 }

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -179,7 +179,7 @@ pub struct TCell<Q, T: ?Sized> {
     // use Invariant<Q> for invariant parameter, not influencing
     // other auto-traits, e.g. UnwindSafe (unlike other solutions like `*mut Q` or `Cell<Q>`)
     owner: PhantomData<Invariant<Q>>,
-    // Disables `Sync`, gives the right `Send` implementation.
+    // Also disables `Sync`, gives the right `Send` implementation.
     // `Sync` is re-enabled below under certain conditions.
     value: UnsafeCell<T>,
 }

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -180,7 +180,9 @@ pub struct TCell<Q, T: ?Sized> {
     // below under certain conditions,
     // use Invariant<Q> for invariant parameter, not influencing
     // other auto-traits like UnwindSafe
-    owner: PhantomData<(*const (), Invariant<Q>)>,
+    owner: PhantomData<Invariant<Q>>,
+    // Disables `Sync`, gives the right `Send` implementation.
+    // `Sync` is re-enabled below under certain conditions.
     value: UnsafeCell<T>,
 }
 
@@ -216,11 +218,6 @@ impl<Q, T: ?Sized> TCell<Q, T> {
         owner.rw(self)
     }
 }
-
-// It's fine to Send a TCell to a different thread if the containted
-// type is Send, because you can only send something if nothing
-// borrows it, so nothing can be accessing its contents.
-unsafe impl<Q, T: Send + ?Sized> Send for TCell<Q, T> {}
 
 // We can add a Sync implementation, since it's fine to send a &TCell
 // to another thread, and even mutably borrow the value there, as long

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -5,9 +5,7 @@ use std::collections::HashSet;
 use std::marker::PhantomData;
 use std::sync::{Condvar, Mutex};
 
-// needs an abstraction as a struct, otherwise we'll get spurious error
-// regarding "function pointers cannot appear in constant functions"
-struct Invariant<Q>(fn(Q) -> Q);
+use super::Invariant;
 
 static SINGLETON_CHECK: Lazy<Mutex<HashSet<TypeId>>> = Lazy::new(|| Mutex::new(HashSet::new()));
 static SINGLETON_CHECK_CONDVAR: Lazy<Condvar> = Lazy::new(Condvar::new);

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -137,7 +137,7 @@ pub struct TLCell<Q, T: ?Sized> {
     // (and Sync, but `UnsafeCell` would already do that, too)
     not_send_or_sync: PhantomData<NotSendOrSync>,
     // use Invariant<Q> for invariant parameter, not influencing
-    // other auto-traits like UnwindSafe
+    // other auto-traits, e.g. UnwindSafe (unlike other solutions like `*mut Q` or `Cell<Q>`)
     owner: PhantomData<Invariant<Q>>,
     value: UnsafeCell<T>,
 }

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -3,9 +3,7 @@ use std::cell::UnsafeCell;
 use std::collections::HashSet;
 use std::marker::PhantomData;
 
-// needs an abstraction as a struct, otherwise we'll get spurious error
-// regarding "function pointers cannot appear in constant functions"
-struct Invariant<Q>(fn(Q) -> Q);
+use super::Invariant;
 
 std::thread_local! {
     static SINGLETON_CHECK: std::cell::RefCell<HashSet<TypeId>> = std::cell::RefCell::new(HashSet::new());


### PR DESCRIPTION
Closes #20

~~I didn’t see any good common place to put `Invariant<Q>` struct, so I put a copy of it in both modules.~~ _Edit:_ Changed in additional commit.