### PR TITLE
Use crossbeam-queue for qcell free list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ categories = [ "data-structures", "memory-management", "rust-patterns" ]
 
 [dependencies]
 once_cell = "1.4.0"
+crossbeam-queue = { version = "0.3", default-features = false, features = ["alloc"] }
 
 [dev-dependencies]
 static_assertions = "1.0"

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -350,8 +350,8 @@ mod tests {
         let id4 = owner4.id;
         let owner5 = QCellOwner::new();
         let id5 = owner5.id;
-        assert_eq!(id4, id1, "Expected ID 1 to be reused");
-        assert_eq!(id5, id3, "Expected ID 3 to be reused");
+        assert!((id1 == id4 || id1 == id5), "Expected ID 1 to be reused");
+        assert!((id3 == id4 || id3 == id5), "Expected ID 3 to be reused");
         assert_ne!(id4, id5, "Expected ID 4/5 to be different");
     }
 

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -81,10 +81,10 @@ impl QCellOwner {
     /// with it to detect using the wrong owner to access a cell at
     /// runtime, which is a programming error.  This call will panic
     /// if the limit of 2^31 owners active at the same time is
-    /// reached.  This is the slow and safe version that uses a mutex
-    /// and a free list to allocate IDs.  If speed of this call
-    /// matters, then consider using [`fast_new()`](#method.fast_new)
-    /// instead.
+    /// reached.  This is the slow and safe version that uses
+    /// non-trivial synchronization and a free list to allocate IDs.
+    /// If speed of this call matters, then consider using
+    /// [`fast_new()`](#method.fast_new) instead.
     ///
     /// This safe version does successfully defend against all
     /// malicious and unsafe use, as far as I am aware.  If not,


### PR DESCRIPTION
I'm working on seeing what it would take to add no_std support to qcell, and the use of Mutex when assigning QCellOwner ids is one obvious sticking point.  This PR proposes replacing the `Lazy<Mutex<SafeQCellOwnerIDSource>>` with `crossbeam_queue::SegQueue` and an `AtomicUsize`.

This will make a future no_std change easier, but it comes with some caveats so I wanted to propose it separately.

Some possible talking points:

- **Additional dependency**:  I targeted only the minimum feature set of crossbeam_queue required to enable this change, but it would still mean qcell has an additional dependency.
- **QCellOwnerId reuse order**:  This change causes IDs to be reused in a FIFO order, rather than LIFO.  The documentation does not specify what order IDs will be reused in, but this is technically an observable change (and I had to slightly edit one of the test cases because of it).
- **Memory allocation pattern changes**:  While this change likely doesn't allocate meaningfully more memory, the way it allocates is subtly changed. Consider an app that `new()`s a large number of QCellOwners, then drops them all, and then `new()`s a similar number.  With the original version, the first drop will allocate a large buffer and never free it, reusing it for the second wave of drops.  The behavior as a consequence of this PR will allocate memory when QCellOwners are dropped, free it when they are reused, and then allocate again when they are dropped a second time.  The change also means that the performance of `QCellOwner::drop` is more consistent, as it will never need to reallocate and copy a potentially large list.
- **AtomicUsize vs AtomicU32**: since IDs are u32s, it might make more sense to use AtomicU32 here, I only didn't because the `FAST_` version was using an AtomicUsize and I figured it was for a reason.  I can hypothesize that AtomicUsize was used previously because the `std` docs suggest it is "generally the most portable".