### PR TITLE
Use memory allocator to generate unique ids in QCell

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -203,7 +203,7 @@
 //! Cell | Owner ID | Cell overhead | Borrow check | Owner check | Owner creation check
 //! ---|---|---|---|---|---
 //! `RefCell` | n/a | `usize` | Runtime | n/a | n/a
-//! `QCell` | integer | `u32` | Compile-time | Runtime | Runtime
+//! `QCell` | integer | `usize` | Compile-time | Runtime | Runtime
 //! `TCell` or `TLCell` | marker type | none | Compile-time | Compile-time | Runtime
 //! `LCell` | lifetime | none | Compile-time | Compile-time | Compile-time
 //!


### PR DESCRIPTION
As discussed, this changes QCell from using a u32 ID type to a pointer type, and relies on the memory allocator to generate unique pointers.

I updated the qcell_ids test to remove the checks for reuse.  Ironically, it actually still passed in debug mode on my machine, but it would rely on implementation details of the memory allocator.

If this gets merged, I'll close the other PR.