### PR TITLE
no_std support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,7 @@ crossbeam = "0.7"
 trybuild = "1.0"
 rustversion = "1.0"
 rand = "0.8"
+
+[package.metadata.docs.rs]
+all-features = true
+rustdoc-args = ["--cfg", "docsrs"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ alloc = []
 once_cell = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
+once_cell = "1.4.0"
 static_assertions = "1.0"
 crossbeam = "0.7"
 trybuild = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,10 @@ documentation = "https://docs.rs/qcell"
 keywords = ["cell","refcell","borrow","borrowing","rc"]
 categories = [ "data-structures", "memory-management", "rust-patterns" ]
 
+[features]
+default = ["std"]
+std = []
+
 [dependencies]
 once_cell = "1.4.0"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,11 @@ categories = [ "data-structures", "memory-management", "rust-patterns" ]
 
 [features]
 default = ["std"]
-std = []
+std = ["alloc", "once_cell"]
+alloc = []
 
 [dependencies]
-once_cell = "1.4.0"
+once_cell = { version = "1.4.0", optional = true }
 
 [dev-dependencies]
 static_assertions = "1.0"

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -6,7 +6,10 @@ use std::panic::RefUnwindSafe;
 use std::panic::UnwindSafe;
 use std::rc::Rc;
 
-use crate::{LCell, LCellOwner, QCell, QCellOwner, TCell, TCellOwner, TLCell, TLCellOwner};
+use crate::{LCell, LCellOwner, QCell, QCellOwner};
+
+#[cfg(feature = "std")]
+use crate::{TCell, TCellOwner, TLCell, TLCellOwner};
 
 // Doesn't do anything, but shows up in list to prove that this file
 // has compiled
@@ -17,47 +20,65 @@ fn test_static_assertions() {}
 struct Q;
 
 // Check owners
-assert_impl_all!(QCellOwner: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
-assert_impl_all!(TCellOwner<Q>: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
 assert_impl_all!(LCellOwner<'_>: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
+assert_impl_all!(QCellOwner: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
+#[cfg(feature = "std")]
+assert_impl_all!(TCellOwner<Q>: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
+#[cfg(feature = "std")]
 assert_impl_all!(TLCellOwner<Q>: Unpin, UnwindSafe, RefUnwindSafe);
+#[cfg(feature = "std")]
 assert_not_impl_any!(TLCellOwner<Q>: Send, Sync);
 
 // Check cells for simple type: i32
-assert_impl_all!(QCell<i32>: Send, Sync, Unpin, UnwindSafe);
-assert_impl_all!(TCell<Q, i32>: Send, Sync, Unpin, UnwindSafe);
 assert_impl_all!(LCell<'_, i32>: Send, Sync, Unpin, UnwindSafe);
+assert_impl_all!(QCell<i32>: Send, Sync, Unpin, UnwindSafe);
+#[cfg(feature = "std")]
+assert_impl_all!(TCell<Q, i32>: Send, Sync, Unpin, UnwindSafe);
+#[cfg(feature = "std")]
 assert_impl_all!(TLCell<Q, i32>: Send, Unpin, UnwindSafe);
+#[cfg(feature = "std")]
 assert_not_impl_any!(TLCell<Q, i32>: Sync);
 
 // Check cells for a !Send !Sync type: Rc<i32>
-assert_impl_all!(QCell<Rc<i32>>: Unpin, UnwindSafe);
-assert_impl_all!(TCell<Q, Rc<i32>>: Unpin, UnwindSafe);
 assert_impl_all!(LCell<'_, Rc<i32>>: Unpin, UnwindSafe);
-assert_impl_all!(TLCell<Q, Rc<i32>>: Unpin, UnwindSafe);
-assert_not_impl_any!(QCell<Rc<i32>>: Send, Sync);
-assert_not_impl_any!(TCell<Q, Rc<i32>>: Send, Sync);
+assert_impl_all!(QCell<Rc<i32>>: Unpin, UnwindSafe);
 assert_not_impl_any!(LCell<'_, Rc<i32>>: Send, Sync);
+assert_not_impl_any!(QCell<Rc<i32>>: Send, Sync);
+#[cfg(feature = "std")]
+assert_impl_all!(TCell<Q, Rc<i32>>: Unpin, UnwindSafe);
+#[cfg(feature = "std")]
+assert_impl_all!(TLCell<Q, Rc<i32>>: Unpin, UnwindSafe);
+#[cfg(feature = "std")]
+assert_not_impl_any!(TCell<Q, Rc<i32>>: Send, Sync);
+#[cfg(feature = "std")]
 assert_not_impl_any!(TLCell<Q, Rc<i32>>: Send, Sync);
 
 // Check cells for a Send !Sync type: Cell<i32>
-assert_impl_all!(QCell<Cell<i32>>: Send, Unpin, UnwindSafe);
-assert_impl_all!(TCell<Q, Cell<i32>>: Send, Unpin, UnwindSafe);
 assert_impl_all!(LCell<'_, Cell<i32>>: Send, Unpin, UnwindSafe);
-assert_impl_all!(TLCell<Q, Cell<i32>>: Send, Unpin, UnwindSafe);
-assert_not_impl_any!(QCell<Cell<i32>>: Sync);
-assert_not_impl_any!(TCell<Q, Cell<i32>>: Sync);
+assert_impl_all!(QCell<Cell<i32>>: Send, Unpin, UnwindSafe);
 assert_not_impl_any!(LCell<'_, Cell<i32>>: Sync);
+assert_not_impl_any!(QCell<Cell<i32>>: Sync);
+#[cfg(feature = "std")]
+assert_impl_all!(TCell<Q, Cell<i32>>: Send, Unpin, UnwindSafe);
+#[cfg(feature = "std")]
+assert_impl_all!(TLCell<Q, Cell<i32>>: Send, Unpin, UnwindSafe);
+#[cfg(feature = "std")]
+assert_not_impl_any!(TCell<Q, Cell<i32>>: Sync);
+#[cfg(feature = "std")]
 assert_not_impl_any!(TLCell<Q, Cell<i32>>: Sync);
 
 // Check cells for a !Send Sync type
 struct Test(*const i32);
 unsafe impl Sync for Test {}
-assert_impl_all!(QCell<Test>: Unpin, UnwindSafe);
-assert_impl_all!(TCell<Q, Test>: Unpin, UnwindSafe);
 assert_impl_all!(LCell<'_, Test>: Unpin, UnwindSafe);
-assert_impl_all!(TLCell<Q, Test>: Unpin, UnwindSafe);
-assert_not_impl_any!(QCell<Test>: Send, Sync);
-assert_not_impl_any!(TCell<Q, Test>: Send, Sync);
+assert_impl_all!(QCell<Test>: Unpin, UnwindSafe);
 assert_not_impl_any!(LCell<'_, Test>: Send, Sync);
+assert_not_impl_any!(QCell<Test>: Send, Sync);
+#[cfg(feature = "std")]
+assert_impl_all!(TCell<Q, Test>: Unpin, UnwindSafe);
+#[cfg(feature = "std")]
+assert_impl_all!(TLCell<Q, Test>: Unpin, UnwindSafe);
+#[cfg(feature = "std")]
+assert_not_impl_any!(TCell<Q, Test>: Send, Sync);
+#[cfg(feature = "std")]
 assert_not_impl_any!(TLCell<Q, Test>: Send, Sync);

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -1,5 +1,5 @@
-use std::cell::UnsafeCell;
-use std::marker::PhantomData;
+use core::cell::UnsafeCell;
+use core::marker::PhantomData;
 
 use super::Invariant;
 type Id<'id> = PhantomData<Invariant<&'id ()>>;
@@ -190,8 +190,10 @@ unsafe impl<'id, T: Send + Sync + ?Sized> Sync for LCell<'id, T> {}
 
 #[cfg(test)]
 mod tests {
+    extern crate alloc;
+
     use super::{LCell, LCellOwner};
-    use std::rc::Rc;
+    use alloc::{boxed::Box, rc::Rc};
 
     #[test]
     fn lcell() {

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -190,10 +190,8 @@ unsafe impl<'id, T: Send + Sync + ?Sized> Sync for LCell<'id, T> {}
 
 #[cfg(test)]
 mod tests {
-    extern crate alloc;
-
     use super::{LCell, LCellOwner};
-    use alloc::{boxed::Box, rc::Rc};
+    use std::rc::Rc;
 
     #[test]
     fn lcell() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -338,8 +338,10 @@
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![deny(rust_2018_idioms)]
 
+#[cfg(feature = "alloc")]
+extern crate alloc;
+
 mod lcell;
-#[cfg(feature = "std")]
 mod qcell;
 #[cfg(feature = "std")]
 mod tcell;
@@ -347,7 +349,7 @@ mod tcell;
 mod tlcell;
 
 pub mod doctest_lcell;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 pub mod doctest_qcell;
 #[cfg(feature = "std")]
 pub mod doctest_tcell;
@@ -377,11 +379,12 @@ struct Invariant<T>(fn(T) -> T);
 
 pub use crate::lcell::LCell;
 pub use crate::lcell::LCellOwner;
+pub use crate::qcell::QCell;
+pub use crate::qcell::QCellOwner;
+pub use crate::qcell::QCellOwnerID;
+
 #[cfg(feature = "std")]
-pub use crate::{
-    qcell::QCell, qcell::QCellOwner, qcell::QCellOwnerID, tcell::TCell, tcell::TCellOwner,
-    tlcell::TLCell, tlcell::TLCellOwner,
-};
+pub use crate::{tcell::TCell, tcell::TCellOwner, tlcell::TLCell, tlcell::TLCellOwner};
 
 // The compile-tests double-check that the compile_fail tests in the
 // doctests actually fail for the reason intended, not for some other
@@ -406,6 +409,9 @@ pub mod compiletest {
         let t = trybuild::TestCases::new();
         if cfg!(feature = "std") {
             t.compile_fail("src/compiletest/*.rs");
+        } else if cfg!(feature = "alloc") {
+            t.compile_fail("src/compiletest/lcell-*.rs");
+            t.compile_fail("src/compiletest/qcell-*.rs");
         } else {
             t.compile_fail("src/compiletest/lcell-*.rs");
         }
@@ -413,5 +419,5 @@ pub mod compiletest {
 }
 
 // Static assertions on traits
-#[cfg(all(test, feature = "std"))]
+#[cfg(test)]
 mod assertions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -335,7 +335,7 @@
 //! [**Migi**]: https://github.com/Migi
 //! [**pythonesque**]: https://github.com/pythonesque
 
-#![cfg_attr(not(feature = "std"), no_std)]
+#![cfg_attr(not(any(feature = "std", test)), no_std)]
 #![deny(rust_2018_idioms)]
 
 mod lcell;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -171,6 +171,7 @@
 //! [`RefCell`] pros and cons:
 //!
 //! - Pro: Simple
+//! - Pro: no_std support
 //! - Pro: Allows very flexible borrowing patterns
 //! - Con: No compile-time borrowing checks
 //! - Con: Can panic due to distant code changes
@@ -179,6 +180,7 @@
 //! [`QCell`] pros and cons:
 //!
 //! - Pro: Simple
+//! - Pro: no_std support
 //! - Pro: Compile-time borrowing checks
 //! - Pro: Dynamic owner creation, not limited in any way
 //! - Pro: No lifetime annotations or type parameters required
@@ -195,6 +197,7 @@
 //! (TLCell), meaning only one owner is allowed per thread or process
 //! per marker type.  Code intended to be nested on the call stack
 //! must be parameterised with an external marker type.
+//! - Con: requires std
 //!
 //! [`LCell`] pros and cons:
 //!
@@ -202,6 +205,7 @@
 //! - Pro: No overhead at runtime for borrowing or ownership checks
 //! - Pro: No cell space overhead
 //! - Pro: No need for singletons, meaning that one use does not limit other nested uses
+//! - Pro: no_std support
 //! - Con: Can only borrow up to 3 objects at a time
 //! - Con: Requires lifetime annotations on calls and structures
 //!
@@ -336,6 +340,7 @@
 //! [**pythonesque**]: https://github.com/pythonesque
 
 #![cfg_attr(not(any(feature = "std", test)), no_std)]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 #![deny(rust_2018_idioms)]
 
 #[cfg(feature = "alloc")]

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -64,6 +64,7 @@ pub struct QCellOwner {
 static FAST_QCELLOWNER_ID: AtomicUsize = AtomicUsize::new(1);
 
 #[cfg(feature = "alloc")]
+#[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
 impl Default for QCellOwner {
     fn default() -> Self {
         QCellOwner::new()
@@ -96,6 +97,7 @@ impl QCellOwner {
     /// owner, because they are no longer of any use without the owner
     /// ID.
     #[cfg(feature = "alloc")]
+    #[cfg_attr(docsrs, doc(cfg(feature = "alloc")))]
     pub fn new() -> Self {
         let handle = Box::new(MAGIC_OWNER_ID_TARGET);
         let raw_ptr: *const OwnerIDTarget = &*handle;

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -14,6 +14,7 @@ static SINGLETON_CHECK_CONDVAR: Lazy<Condvar> = Lazy::new(Condvar::new);
 /// instances.
 ///
 /// See [crate documentation](index.html).
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct TCellOwner<Q: 'static> {
     // Allow Send and Sync, and Q is invariant
     typ: PhantomData<Invariant<Q>>,
@@ -175,6 +176,7 @@ impl<Q: 'static> TCellOwner<Q> {
 /// See also [crate documentation](index.html).
 ///
 /// [`TCellOwner`]: struct.TCellOwner.html
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct TCell<Q, T: ?Sized> {
     // Use Invariant<Q> for invariant parameter
     owner: PhantomData<Invariant<Q>>,

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -15,6 +15,7 @@ struct NotSendOrSync(*const ());
 /// instances.
 ///
 /// See [crate documentation](index.html).
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct TLCellOwner<Q: 'static> {
     // Use NotSendOrSync to disable Send and Sync,
     not_send_or_sync: PhantomData<NotSendOrSync>,
@@ -131,6 +132,7 @@ impl<Q: 'static> TLCellOwner<Q> {
 /// See also [crate documentation](index.html).
 ///
 /// [`TLCellOwner`]: struct.TLCellOwner.html
+#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct TLCell<Q, T: ?Sized> {
     // Use Invariant<Q> for invariant parameter
     owner: PhantomData<Invariant<Q>>,


### PR DESCRIPTION
This implementation has `LCell` and `QCell` (`fast_new` only) fully supported on no_std.
If you enable the `alloc` feature, you gain `QCell::new`.
TCell and TLCell are supported only under the `std` feature.

This shouldn't touch any functional code, just modify some imports, add feature gates, and tweak documentation. 

Tests for items that aren't available are not enabled.  This excludes most of the `QCell` tests when the `alloc` feature is disabled, as they rely on `QCell::new`.  Here are the my test counts:

- `cargo test --no-default-features`:  8 tests, 25 doc-tests.
- `cargo test --no-default-features --features "alloc"`:  13 doc-tests, 45 doc-tests.
- `cargo test` and `cargo test --no-default-features --features "std"`:  28 tests, 92 doc-tests.

There is one doc-test in lib.rs that I had to add the `std` feature-gate to, this makes it look a little funny in the source code but the resulting HTML documentation is unchanged.

I just shuffled some things around in `assertions.rs` to group the feature-gated ones, but feel free to double check that I didn't accidentally delete any.