### PR TITLE
Pinned version of QCellOwner

### DIFF
--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -6,7 +6,7 @@ use std::panic::RefUnwindSafe;
 use std::panic::UnwindSafe;
 use std::rc::Rc;
 
-use crate::{LCell, LCellOwner, QCell, QCellOwner};
+use crate::{LCell, LCellOwner, QCell, QCellOwner, QCellOwnerPinned};
 
 #[cfg(feature = "std")]
 use crate::{TCell, TCellOwner, TLCell, TLCellOwner};
@@ -22,6 +22,8 @@ struct Q;
 // Check owners
 assert_impl_all!(LCellOwner<'_>: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
 assert_impl_all!(QCellOwner: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
+assert_impl_all!(QCellOwnerPinned: Send, Sync, UnwindSafe, RefUnwindSafe);
+assert_not_impl_any!(QCellOwnerPinned: Unpin);
 #[cfg(feature = "std")]
 assert_impl_all!(TCellOwner<Q>: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
 #[cfg(feature = "std")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -387,6 +387,7 @@ pub use crate::lcell::LCellOwner;
 pub use crate::qcell::QCell;
 pub use crate::qcell::QCellOwner;
 pub use crate::qcell::QCellOwnerID;
+pub use crate::qcell::QCellOwnerPinned;
 
 #[cfg(feature = "std")]
 pub use crate::{tcell::TCell, tcell::TCellOwner, tlcell::TLCell, tlcell::TLCellOwner};


### PR DESCRIPTION
This adds another owner type for `QCell`, `QCellOwnerPinned`.  Since we changed `QCell` to use memory addresses, we can get a fixed memory address from a pinned reference just as reliably as a from the memory allocator.

Pros:
- No global state.
- Fully no_std, usable without `alloc`.
- Performance.  I hypothesize `QCellOwnerPinned::new` is significantly faster even than `QCellOwner::fast_new`.

Cons:
- While I believe this API is fully safe, Pin has historically not been something people new to Rust understand well.  The existence of this API may encourage them to use unsafe to interact with Pin, and they might not uphold the contract.  A user doing something unsound with unsafe is not the responsibility of qcell, but it would be understandable if you want to avoid that nontheless.
- This likely locks the internals into the implementation based on memory addresses.  Going back to the original QCellOwnerID implementation likely wouldn't be possible without removing this (and triggering a SemVer breaking change). 

I'm creating this as a draft PR without comprehensive tests to gather feedback.  If it seems like a good idea, I can work on implementing tests for it.