### PR TITLE
Prepare for 0.5.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,30 @@ This project follows Rust semantic versioning.
 
 <!-- see keepachangelog.com for format ideas -->
 
+## 0.5.0
+
+### Changed
+
+- `QCellOwner` is now based on IDs derived from the addresses of
+  heap-allocated objects.  This change was contributed by [Violet
+  Leonard](https://github.com/geeklint).  This offloads maintaining
+  lists of in-use IDs to the allocator, which improves `no_std`
+  compatibility.
+
+### Added
+
+- `no_std` support in `QCell` and `LCell`, contributed by [Violet
+  Leonard](https://github.com/geeklint).
+
+- `QCellOwnerPinned` (contributed by [Violet
+  Leonard](https://github.com/geeklint)), and `QCellOwnerSeq`.  These
+  now form a family of ID-based owners along with `QCellOwner`.
+
+### Breaking
+
+- `QCellOwner::fast_new` is replaced by `QCellOwnerSeq::new`
+
+
 ## 0.4.3 (2021-09-20)
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,12 +25,17 @@ once_cell = { version = "1.4.0", optional = true }
 [dev-dependencies]
 crossbeam = "0.7"
 once_cell = "1.4.0"
+pin-project = "1"
 pin-utils = "0.1"
 rand = "0.8"
 rustversion = "1.0"
 static_assertions = "1.0"
 trybuild = "1.0"
 
+
+# For docs.rs, build docs with feature labels.  Search for `docsrs` in
+# source to see the things that are labelled.  To test this use:
+# RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/run-clippy-all
+++ b/run-clippy-all
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cargo clippy &&
+cargo clippy --no-default-features --features alloc &&
+cargo clippy --no-default-features

--- a/run-doc-all
+++ b/run-doc-all
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# First build with all combinations of features to check for doc
+# issues (bad links etc, e.g. especially references to QCellOwner from
+# no_std docs).  Then finally build as docs.rs sees it to visually
+# check the "std" and "alloc" annotations on some types.
+
+cargo doc &&
+cargo doc --no-default-features --features alloc &&
+cargo doc --no-default-features &&
+RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features

--- a/run-test-all
+++ b/run-test-all
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+cargo test &&
+cargo test --no-default-features --features alloc &&
+cargo test --no-default-features

--- a/src/assertions.rs
+++ b/src/assertions.rs
@@ -6,7 +6,10 @@ use std::panic::RefUnwindSafe;
 use std::panic::UnwindSafe;
 use std::rc::Rc;
 
-use crate::{LCell, LCellOwner, QCell, QCellOwner, QCellOwnerPinned};
+use crate::{LCell, LCellOwner, QCell, QCellOwnerPinned};
+
+#[cfg(features = "alloc")]
+use crate::QCellOwner;
 
 #[cfg(feature = "std")]
 use crate::{TCell, TCellOwner, TLCell, TLCellOwner};
@@ -21,6 +24,7 @@ struct Q;
 
 // Check owners
 assert_impl_all!(LCellOwner<'_>: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
+#[cfg(features = "alloc")]
 assert_impl_all!(QCellOwner: Send, Sync, Unpin, UnwindSafe, RefUnwindSafe);
 assert_impl_all!(QCellOwnerPinned: Send, Sync, UnwindSafe, RefUnwindSafe);
 assert_not_impl_any!(QCellOwnerPinned: Unpin);

--- a/src/compiletest/lcell-00.stderr
+++ b/src/compiletest/lcell-00.stderr
@@ -1,9 +1,9 @@
 error[E0382]: borrow of moved value: `owner1`
- --> $DIR/lcell-00.rs:9:26
+ --> src/compiletest/lcell-00.rs:9:26
   |
 7 |     LCellOwner::scope(|mut owner1| {
   |                        ---------- move occurs because `owner1` has type `LCellOwner<'_>`, which does not implement the `Copy` trait
 8 |         let owner2 = owner1;
   |                      ------ value moved here
 9 |         let rc = Rc::new(owner1.cell(100u32)); // Compile fail
-  |                          ^^^^^^ value borrowed here after move
+  |                          ^^^^^^^^^^^^^^^^^^^ value borrowed here after move

--- a/src/compiletest/lcell-02.stderr
+++ b/src/compiletest/lcell-02.stderr
@@ -1,11 +1,11 @@
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'id` due to conflicting requirements
-  --> $DIR/lcell-02.rs:10:33
+  --> src/compiletest/lcell-02.rs:10:33
    |
 10 |             let c1ref1 = owner1.ro(&c1);
    |                                 ^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the body at 8:27...
-  --> $DIR/lcell-02.rs:8:27
+note: first, the lifetime cannot outlive the anonymous lifetime #1 defined here...
+  --> src/compiletest/lcell-02.rs:8:27
    |
 8  |           LCellOwner::scope(|mut owner2| {
    |  ___________________________^
@@ -15,8 +15,8 @@ note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on th
 12 | |             println!("{}", *c1ref2);
 13 | |         });
    | |_________^
-note: ...but the lifetime must also be valid for the anonymous lifetime #1 defined on the body at 7:23...
-  --> $DIR/lcell-02.rs:7:23
+note: ...but the lifetime must also be valid for the anonymous lifetime #1 defined here...
+  --> src/compiletest/lcell-02.rs:7:23
    |
 7  |       LCellOwner::scope(|mut owner1| {
    |  _______________________^
@@ -28,7 +28,7 @@ note: ...but the lifetime must also be valid for the anonymous lifetime #1 defin
 14 | |     });
    | |_____^
 note: ...so that the types are compatible
-  --> $DIR/lcell-02.rs:11:33
+  --> src/compiletest/lcell-02.rs:11:33
    |
 11 |             let c1ref2 = owner2.ro(&c1);   // Compile error
    |                                 ^^

--- a/src/compiletest/lcell-03.stderr
+++ b/src/compiletest/lcell-03.stderr
@@ -1,11 +1,11 @@
 error[E0495]: cannot infer an appropriate lifetime for lifetime parameter `'id` due to conflicting requirements
-  --> $DIR/lcell-03.rs:9:37
+  --> src/compiletest/lcell-03.rs:9:37
    |
 9  |             let c1 = Rc::new(owner1.cell(100u32));
    |                                     ^^^^
    |
-note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on the body at 8:27...
-  --> $DIR/lcell-03.rs:8:27
+note: first, the lifetime cannot outlive the anonymous lifetime #1 defined here...
+  --> src/compiletest/lcell-03.rs:8:27
    |
 8  |           LCellOwner::scope(|mut owner2| {
    |  ___________________________^
@@ -15,14 +15,14 @@ note: first, the lifetime cannot outlive the anonymous lifetime #1 defined on th
 12 | |         });
    | |_________^
 note: ...so that the types are compatible
-  --> $DIR/lcell-03.rs:10:36
+  --> src/compiletest/lcell-03.rs:10:36
    |
 10 |             let c1mutref2 = owner2.rw(&c1);    // Compile error
    |                                    ^^
    = note: expected `&mut LCellOwner<'_>`
               found `&mut LCellOwner<'_>`
-note: but, the lifetime must be valid for the anonymous lifetime #1 defined on the body at 7:23...
-  --> $DIR/lcell-03.rs:7:23
+note: but, the lifetime must be valid for the anonymous lifetime #1 defined here...
+  --> src/compiletest/lcell-03.rs:7:23
    |
 7  |       LCellOwner::scope(|mut owner1| {
    |  _______________________^
@@ -34,7 +34,7 @@ note: but, the lifetime must be valid for the anonymous lifetime #1 defined on t
 13 | |     });
    | |_____^
 note: ...so that the types are compatible
-  --> $DIR/lcell-03.rs:9:37
+  --> src/compiletest/lcell-03.rs:9:37
    |
 9  |             let c1 = Rc::new(owner1.cell(100u32));
    |                                     ^^^^

--- a/src/compiletest/lcell-04.stderr
+++ b/src/compiletest/lcell-04.stderr
@@ -1,9 +1,9 @@
 error[E0499]: cannot borrow `owner` as mutable more than once at a time
-  --> $DIR/lcell-04.rs:12:24
+  --> src/compiletest/lcell-04.rs:12:24
    |
 11 |         let c1mutref = owner.rw(&c1);
-   |                        ----- first mutable borrow occurs here
+   |                        ------------- first mutable borrow occurs here
 12 |         let c2mutref = owner.rw(&c2);  // Compile error
-   |                        ^^^^^ second mutable borrow occurs here
+   |                        ^^^^^^^^^^^^^ second mutable borrow occurs here
 13 |         *c1mutref += 1;
    |         -------------- first borrow later used here

--- a/src/compiletest/lcell-05.stderr
+++ b/src/compiletest/lcell-05.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
-  --> $DIR/lcell-05.rs:11:24
+  --> src/compiletest/lcell-05.rs:11:24
    |
 10 |         let c1ref = owner.ro(&c1);
-   |                     ----- immutable borrow occurs here
+   |                     ------------- immutable borrow occurs here
 11 |         let c1mutref = owner.rw(&c1);    // Compile error
    |                        ^^^^^^^^^^^^^ mutable borrow occurs here
 12 |         println!("{}", *c1ref);

--- a/src/compiletest/lcell-06.stderr
+++ b/src/compiletest/lcell-06.stderr
@@ -1,9 +1,9 @@
 error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
-  --> $DIR/lcell-06.rs:11:21
+  --> src/compiletest/lcell-06.rs:11:21
    |
 10 |         let c1mutref = owner.rw(&c1);
-   |                        ----- mutable borrow occurs here
+   |                        ------------- mutable borrow occurs here
 11 |         let c2ref = owner.ro(&c2);    // Compile error
-   |                     ^^^^^ immutable borrow occurs here
+   |                     ^^^^^^^^^^^^^ immutable borrow occurs here
 12 |         *c1mutref += 1;
    |         -------------- mutable borrow later used here

--- a/src/compiletest/lcell-08.stderr
+++ b/src/compiletest/lcell-08.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
-  --> $DIR/lcell-08.rs:12:14
+  --> src/compiletest/lcell-08.rs:12:14
    |
 11 |         let c1ref = owner.ro(&c1);
-   |                     ----- immutable borrow occurs here
+   |                     ------------- immutable borrow occurs here
 12 |         test(&mut owner);    // Compile error
    |              ^^^^^^^^^^ mutable borrow occurs here
 13 |         println!("{}", *c1ref);

--- a/src/compiletest/lcell-09.stderr
+++ b/src/compiletest/lcell-09.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
-  --> $DIR/lcell-09.rs:12:14
+  --> src/compiletest/lcell-09.rs:12:14
    |
 11 |         let c1mutref = owner.rw(&c1);
-   |                        ----- mutable borrow occurs here
+   |                        ------------- mutable borrow occurs here
 12 |         test(&owner);    // Compile error
    |              ^^^^^^ immutable borrow occurs here
 13 |         *c1mutref += 1;

--- a/src/compiletest/lcell-10.stderr
+++ b/src/compiletest/lcell-10.stderr
@@ -1,18 +1,18 @@
 error[E0505]: cannot move out of `owner` because it is borrowed
-  --> $DIR/lcell-10.rs:9:26
+  --> src/compiletest/lcell-10.rs:9:26
    |
 8  |         let val_ref = owner.ro(&cell);
-   |                       ----- borrow of `owner` occurs here
+   |                       --------------- borrow of `owner` occurs here
 9  |         crossbeam::scope(move |s| {
    |                          ^^^^^^^^ move out of `owner` occurs here
 10 |             s.spawn(move |_| assert_eq!(*owner.ro(&cell), 100)).join().unwrap(); // Compile fail
    |                                          ----- move occurs due to use in closure
 11 |         }).unwrap();
 12 |         assert_eq!(*val_ref, 100);
-   |         -------------------------- borrow later used here
+   |         ------------------------- borrow later used here
 
 error[E0505]: cannot move out of `cell` because it is borrowed
-  --> $DIR/lcell-10.rs:9:26
+  --> src/compiletest/lcell-10.rs:9:26
    |
 8  |         let val_ref = owner.ro(&cell);
    |                                ----- borrow of `cell` occurs here
@@ -22,4 +22,4 @@ error[E0505]: cannot move out of `cell` because it is borrowed
    |                                                    ---- move occurs due to use in closure
 11 |         }).unwrap();
 12 |         assert_eq!(*val_ref, 100);
-   |         -------------------------- borrow later used here
+   |         ------------------------- borrow later used here

--- a/src/compiletest/lcell-11.stderr
+++ b/src/compiletest/lcell-11.stderr
@@ -1,10 +1,13 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
- --> $DIR/lcell-11.rs:8:5
+ --> src/compiletest/lcell-11.rs:8:5
   |
-7 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
 8 |     is_sync::<LCell<'_, Cell<i32>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
   |
   = help: the trait `Sync` is not implemented for `Cell<i32>`
   = note: required because of the requirements on the impl of `Sync` for `LCell<'_, Cell<i32>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/lcell-11.rs:7:19
+  |
+7 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/lcell-12.stderr
+++ b/src/compiletest/lcell-12.stderr
@@ -1,10 +1,15 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
-  --> $DIR/lcell-12.rs:12:28
-   |
-12 |             let handle = s.spawn(|_| owner.ro(&cell).set(200));
-   |                            ^^^^^ `Cell<i32>` cannot be shared between threads safely
-   |
-   = help: the trait `Sync` is not implemented for `Cell<i32>`
-   = note: required because of the requirements on the impl of `Sync` for `LCell<'_, Cell<i32>>`
-   = note: required because of the requirements on the impl of `Send` for `&LCell<'_, Cell<i32>>`
-   = note: required because it appears within the type `[closure@$DIR/src/compiletest/lcell-12.rs:12:34: 12:62]`
+   --> src/compiletest/lcell-12.rs:12:28
+    |
+12  |             let handle = s.spawn(|_| owner.ro(&cell).set(200));
+    |                            ^^^^^ `Cell<i32>` cannot be shared between threads safely
+    |
+    = help: the trait `Sync` is not implemented for `Cell<i32>`
+    = note: required because of the requirements on the impl of `Sync` for `LCell<'_, Cell<i32>>`
+    = note: required because of the requirements on the impl of `Send` for `&LCell<'_, Cell<i32>>`
+    = note: required because it appears within the type `[closure@$DIR/src/compiletest/lcell-12.rs:12:34: 12:62]`
+note: required by a bound in `Scope::<'env>::spawn`
+   --> $CARGO/crossbeam-utils-0.7.2/src/thread.rs
+    |
+    |         F: Send + 'env,
+    |            ^^^^ required by this bound in `Scope::<'env>::spawn`

--- a/src/compiletest/lcell-13.stderr
+++ b/src/compiletest/lcell-13.stderr
@@ -1,21 +1,27 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
- --> $DIR/lcell-13.rs:9:5
+ --> src/compiletest/lcell-13.rs:9:5
   |
-8 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
 9 |     is_sync::<LCell<'_, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
   = help: the trait `Send` is not implemented for `Rc<()>`
   = note: required because of the requirements on the impl of `Sync` for `LCell<'_, Rc<()>>`
-
-error[E0277]: `Rc<()>` cannot be shared between threads safely
- --> $DIR/lcell-13.rs:9:5
+note: required by a bound in `is_sync`
+ --> src/compiletest/lcell-13.rs:8:19
   |
 8 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
+  |                   ^^^^ required by this bound in `is_sync`
+
+error[E0277]: `Rc<()>` cannot be shared between threads safely
+ --> src/compiletest/lcell-13.rs:9:5
+  |
 9 |     is_sync::<LCell<'_, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be shared between threads safely
   |
   = help: the trait `Sync` is not implemented for `Rc<()>`
   = note: required because of the requirements on the impl of `Sync` for `LCell<'_, Rc<()>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/lcell-13.rs:8:19
+  |
+8 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/lcell-14.stderr
+++ b/src/compiletest/lcell-14.stderr
@@ -1,11 +1,14 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
- --> $DIR/lcell-14.rs:9:5
+ --> src/compiletest/lcell-14.rs:9:5
   |
-8 |     fn is_send<T: Send>() {}
-  |                   ---- required by this bound in `is_send`
 9 |     is_send::<LCell<'_, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
   = help: within `LCell<'_, Rc<()>>`, the trait `Send` is not implemented for `Rc<()>`
   = note: required because it appears within the type `UnsafeCell<Rc<()>>`
   = note: required because it appears within the type `LCell<'_, Rc<()>>`
+note: required by a bound in `is_send`
+ --> src/compiletest/lcell-14.rs:8:19
+  |
+8 |     fn is_send<T: Send>() {}
+  |                   ^^^^ required by this bound in `is_send`

--- a/src/compiletest/lcell-15.stderr
+++ b/src/compiletest/lcell-15.stderr
@@ -1,12 +1,17 @@
 error[E0277]: `Rc<i32>` cannot be sent between threads safely
-  --> $DIR/lcell-15.rs:12:15
-   |
-12 |             s.spawn(move |_| assert_eq!(100, **owner.ro(&cell))).join().unwrap(); // Compile fail
-   |               ^^^^^ ------------------------------------------- within this `[closure@$DIR/src/compiletest/lcell-15.rs:12:21: 12:64]`
-   |               |
-   |               `Rc<i32>` cannot be sent between threads safely
-   |
-   = help: within `[closure@$DIR/src/compiletest/lcell-15.rs:12:21: 12:64]`, the trait `Send` is not implemented for `Rc<i32>`
-   = note: required because it appears within the type `UnsafeCell<Rc<i32>>`
-   = note: required because it appears within the type `LCell<'_, Rc<i32>>`
-   = note: required because it appears within the type `[closure@$DIR/src/compiletest/lcell-15.rs:12:21: 12:64]`
+   --> src/compiletest/lcell-15.rs:12:15
+    |
+12  |             s.spawn(move |_| assert_eq!(100, **owner.ro(&cell))).join().unwrap(); // Compile fail
+    |               ^^^^^ ------------------------------------------- within this `[closure@$DIR/src/compiletest/lcell-15.rs:12:21: 12:64]`
+    |               |
+    |               `Rc<i32>` cannot be sent between threads safely
+    |
+    = help: within `[closure@$DIR/src/compiletest/lcell-15.rs:12:21: 12:64]`, the trait `Send` is not implemented for `Rc<i32>`
+    = note: required because it appears within the type `UnsafeCell<Rc<i32>>`
+    = note: required because it appears within the type `LCell<'_, Rc<i32>>`
+    = note: required because it appears within the type `[closure@$DIR/src/compiletest/lcell-15.rs:12:21: 12:64]`
+note: required by a bound in `Scope::<'env>::spawn`
+   --> $CARGO/crossbeam-utils-0.7.2/src/thread.rs
+    |
+    |         F: Send + 'env,
+    |            ^^^^ required by this bound in `Scope::<'env>::spawn`

--- a/src/compiletest/qcell-02.stderr
+++ b/src/compiletest/qcell-02.stderr
@@ -1,9 +1,9 @@
 error[E0499]: cannot borrow `owner` as mutable more than once at a time
-  --> $DIR/qcell-02.rs:12:20
+  --> src/compiletest/qcell-02.rs:12:20
    |
 11 |     let c1mutref = owner.rw(&c1);
-   |                    ----- first mutable borrow occurs here
+   |                    ------------- first mutable borrow occurs here
 12 |     let c2mutref=  owner.rw(&c2);  // Compile error
-   |                    ^^^^^ second mutable borrow occurs here
+   |                    ^^^^^^^^^^^^^ second mutable borrow occurs here
 13 |     *c1mutref += 1;
    |     -------------- first borrow later used here

--- a/src/compiletest/qcell-03.stderr
+++ b/src/compiletest/qcell-03.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
-  --> $DIR/qcell-03.rs:11:20
+  --> src/compiletest/qcell-03.rs:11:20
    |
 10 |     let c1ref = owner.ro(&c1);
-   |                 ----- immutable borrow occurs here
+   |                 ------------- immutable borrow occurs here
 11 |     let c1mutref = owner.rw(&c1);    // Compile error
    |                    ^^^^^^^^^^^^^ mutable borrow occurs here
 12 |     println!("{}", *c1ref);

--- a/src/compiletest/qcell-04.stderr
+++ b/src/compiletest/qcell-04.stderr
@@ -1,9 +1,9 @@
 error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
-  --> $DIR/qcell-04.rs:11:17
+  --> src/compiletest/qcell-04.rs:11:17
    |
 10 |     let c1mutref = owner.rw(&c1);
-   |                    ----- mutable borrow occurs here
+   |                    ------------- mutable borrow occurs here
 11 |     let c2ref = owner.ro(&c2);    // Compile error
-   |                 ^^^^^ immutable borrow occurs here
+   |                 ^^^^^^^^^^^^^ immutable borrow occurs here
 12 |     *c1mutref += 1;
    |     -------------- mutable borrow later used here

--- a/src/compiletest/qcell-06.stderr
+++ b/src/compiletest/qcell-06.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
-  --> $DIR/qcell-06.rs:13:10
+  --> src/compiletest/qcell-06.rs:13:10
    |
 12 |     let c1ref = owner.ro(&c1);
-   |                 ----- immutable borrow occurs here
+   |                 ------------- immutable borrow occurs here
 13 |     test(&mut owner);    // Compile error
    |          ^^^^^^^^^^ mutable borrow occurs here
 14 |     println!("{}", *c1ref);

--- a/src/compiletest/qcell-07.stderr
+++ b/src/compiletest/qcell-07.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
-  --> $DIR/qcell-07.rs:13:10
+  --> src/compiletest/qcell-07.rs:13:10
    |
 12 |     let c1mutref = owner.rw(&c1);
-   |                    ----- mutable borrow occurs here
+   |                    ------------- mutable borrow occurs here
 13 |     test(&owner);    // Compile error
    |          ^^^^^^ immutable borrow occurs here
 14 |     *c1mutref += 1;

--- a/src/compiletest/qcell-08.stderr
+++ b/src/compiletest/qcell-08.stderr
@@ -1,18 +1,18 @@
 error[E0505]: cannot move out of `owner` because it is borrowed
-  --> $DIR/qcell-08.rs:9:24
+  --> src/compiletest/qcell-08.rs:9:24
    |
 8  |     let val_ref = owner.ro(&cell);
-   |                   ----- borrow of `owner` occurs here
+   |                   --------------- borrow of `owner` occurs here
 9  |     std::thread::spawn(move || {
    |                        ^^^^^^^ move out of `owner` occurs here
 10 |         assert_eq!(*owner.ro(&cell), 100);
    |                     ----- move occurs due to use in closure
 11 |     }).join();
 12 |     assert_eq!(*val_ref, 100);
-   |     -------------------------- borrow later used here
+   |     ------------------------- borrow later used here
 
 error[E0505]: cannot move out of `cell` because it is borrowed
-  --> $DIR/qcell-08.rs:9:24
+  --> src/compiletest/qcell-08.rs:9:24
    |
 8  |     let val_ref = owner.ro(&cell);
    |                            ----- borrow of `cell` occurs here
@@ -22,4 +22,4 @@ error[E0505]: cannot move out of `cell` because it is borrowed
    |                               ---- move occurs due to use in closure
 11 |     }).join();
 12 |     assert_eq!(*val_ref, 100);
-   |     -------------------------- borrow later used here
+   |     ------------------------- borrow later used here

--- a/src/compiletest/qcell-09.stderr
+++ b/src/compiletest/qcell-09.stderr
@@ -1,10 +1,13 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
- --> $DIR/qcell-09.rs:8:5
+ --> src/compiletest/qcell-09.rs:8:5
   |
-7 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
 8 |     is_sync::<QCell<Cell<i32>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
   |
   = help: the trait `Sync` is not implemented for `Cell<i32>`
   = note: required because of the requirements on the impl of `Sync` for `QCell<Cell<i32>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/qcell-09.rs:7:19
+  |
+7 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/qcell-10.stderr
+++ b/src/compiletest/qcell-10.stderr
@@ -1,15 +1,15 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
-   --> $DIR/qcell-10.rs:11:5
+   --> src/compiletest/qcell-10.rs:11:5
     |
 11  |     std::thread::spawn(|| owner.ro(&cell).set(200));  // Compile fail
     |     ^^^^^^^^^^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
-    |
-   ::: $RUST/std/src/thread/mod.rs
-    |
-    |     F: Send + 'static,
-    |        ---- required by this bound in `spawn`
     |
     = help: the trait `Sync` is not implemented for `Cell<i32>`
     = note: required because of the requirements on the impl of `Sync` for `QCell<Cell<i32>>`
     = note: required because of the requirements on the impl of `Send` for `&QCell<Cell<i32>>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/qcell-10.rs:11:24: 11:51]`
+note: required by a bound in `spawn`
+   --> $RUST/std/src/thread/mod.rs
+    |
+    |     F: Send + 'static,
+    |        ^^^^ required by this bound in `spawn`

--- a/src/compiletest/qcell-11.stderr
+++ b/src/compiletest/qcell-11.stderr
@@ -1,21 +1,27 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
- --> $DIR/qcell-11.rs:8:5
+ --> src/compiletest/qcell-11.rs:8:5
   |
-7 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
 8 |     is_sync::<QCell<Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
   = help: the trait `Send` is not implemented for `Rc<()>`
   = note: required because of the requirements on the impl of `Sync` for `QCell<Rc<()>>`
-
-error[E0277]: `Rc<()>` cannot be shared between threads safely
- --> $DIR/qcell-11.rs:8:5
+note: required by a bound in `is_sync`
+ --> src/compiletest/qcell-11.rs:7:19
   |
 7 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
+  |                   ^^^^ required by this bound in `is_sync`
+
+error[E0277]: `Rc<()>` cannot be shared between threads safely
+ --> src/compiletest/qcell-11.rs:8:5
+  |
 8 |     is_sync::<QCell<Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be shared between threads safely
   |
   = help: the trait `Sync` is not implemented for `Rc<()>`
   = note: required because of the requirements on the impl of `Sync` for `QCell<Rc<()>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/qcell-11.rs:7:19
+  |
+7 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/qcell-12.stderr
+++ b/src/compiletest/qcell-12.stderr
@@ -1,11 +1,14 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
- --> $DIR/qcell-12.rs:8:5
+ --> src/compiletest/qcell-12.rs:8:5
   |
-7 |     fn is_send<T: Send>() {}
-  |                   ---- required by this bound in `is_send`
 8 |     is_send::<QCell<Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
   = help: within `QCell<Rc<()>>`, the trait `Send` is not implemented for `Rc<()>`
   = note: required because it appears within the type `UnsafeCell<Rc<()>>`
   = note: required because it appears within the type `QCell<Rc<()>>`
+note: required by a bound in `is_send`
+ --> src/compiletest/qcell-12.rs:7:19
+  |
+7 |     fn is_send<T: Send>() {}
+  |                   ^^^^ required by this bound in `is_send`

--- a/src/compiletest/qcell-13.stderr
+++ b/src/compiletest/qcell-13.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `Rc<i32>` cannot be sent between threads safely
-   --> $DIR/qcell-13.rs:11:5
+   --> src/compiletest/qcell-13.rs:11:5
     |
 11  |       std::thread::spawn(move || {    // Compile fail
     |  _____^^^^^^^^^^^^^^^^^^_-
@@ -9,12 +9,12 @@ error[E0277]: `Rc<i32>` cannot be sent between threads safely
 13  | |     }).join();
     | |_____- within this `[closure@$DIR/src/compiletest/qcell-13.rs:11:24: 13:6]`
     |
-   ::: $RUST/std/src/thread/mod.rs
-    |
-    |       F: Send + 'static,
-    |          ---- required by this bound in `spawn`
-    |
     = help: within `[closure@$DIR/src/compiletest/qcell-13.rs:11:24: 13:6]`, the trait `Send` is not implemented for `Rc<i32>`
     = note: required because it appears within the type `UnsafeCell<Rc<i32>>`
     = note: required because it appears within the type `QCell<Rc<i32>>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/qcell-13.rs:11:24: 13:6]`
+note: required by a bound in `spawn`
+   --> $RUST/std/src/thread/mod.rs
+    |
+    |     F: Send + 'static,
+    |        ^^^^ required by this bound in `spawn`

--- a/src/compiletest/qcell_noalloc-00.stderr
+++ b/src/compiletest/qcell_noalloc-00.stderr
@@ -1,0 +1,15 @@
+error[E0599]: no method named `id` found for struct `QCellOwnerPinned` in the current scope
+   --> src/compiletest/qcell_noalloc-00.rs:7:21
+    |
+7   |     let id = owner1.id();
+    |                     ^^ method not found in `QCellOwnerPinned`
+    |
+   ::: src/qcell.rs:600:12
+    |
+600 |     pub fn id(self: Pin<&Self>) -> QCellOwnerID {
+    |            -- the method is available for `Pin<&QCellOwnerPinned>` here
+    |
+help: consider wrapping the receiver expression with the appropriate type
+    |
+7   |     let id = Pin::new(&owner1).id();
+    |              ++++++++++      +

--- a/src/compiletest/qcell_noalloc-01.stderr
+++ b/src/compiletest/qcell_noalloc-01.stderr
@@ -1,0 +1,13 @@
+error[E0277]: `PhantomPinned` cannot be unpinned
+ --> src/compiletest/qcell_noalloc-01.rs:7:5
+  |
+7 |     is_unpin::<QCellOwnerPinned>();
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ within `QCellOwnerPinned`, the trait `Unpin` is not implemented for `PhantomPinned`
+  |
+  = note: consider using `Box::pin`
+  = note: required because it appears within the type `QCellOwnerPinned`
+note: required by a bound in `is_unpin`
+ --> src/compiletest/qcell_noalloc-01.rs:6:20
+  |
+6 |     fn is_unpin<T: Unpin>() {}
+  |                    ^^^^^ required by this bound in `is_unpin`

--- a/src/compiletest/qcell_noalloc-02.stderr
+++ b/src/compiletest/qcell_noalloc-02.stderr
@@ -1,0 +1,11 @@
+error[E0382]: use of moved value: `owner1`
+  --> src/compiletest/qcell_noalloc-02.rs:10:5
+   |
+8  |     let mut owner1 = QCellOwnerPinned::new();
+   |         ---------- move occurs because `owner1` has type `QCellOwnerPinned`, which does not implement the `Copy` trait
+9  |     let mut owner2 = owner1;
+   |                      ------ value moved here
+10 |     pin_mut!(owner1);  // Compile fail
+   |     ^^^^^^^^^^^^^^^^ value used here after move
+   |
+   = note: this error originates in the macro `pin_mut` (in Nightly builds, run with -Z macro-backtrace for more info)

--- a/src/compiletest/qcell_noalloc-03.stderr
+++ b/src/compiletest/qcell_noalloc-03.stderr
@@ -1,0 +1,9 @@
+error[E0382]: borrow of moved value: `owner1`
+  --> src/compiletest/qcell_noalloc-03.rs:11:22
+   |
+9  |     pin_mut!(owner1);
+   |     ---------------- move occurs because `owner1` has type `Pin<&mut QCellOwnerPinned>`, which does not implement the `Copy` trait
+10 |     let mut owner2 = owner1;
+   |                      ------ value moved here
+11 |     let rc = Rc::new(owner1.as_ref().cell(100u32));  // Compile fail
+   |                      ^^^^^^^^^^^^^^^ value borrowed here after move

--- a/src/compiletest/qcell_noalloc-04.stderr
+++ b/src/compiletest/qcell_noalloc-04.stderr
@@ -1,0 +1,5 @@
+error[E0599]: no method named `clone` found for struct `QCellOwnerPinned` in the current scope
+ --> src/compiletest/qcell_noalloc-04.rs:8:25
+  |
+8 |     let owner2 = owner1.clone();  // Compile fail
+  |                         ^^^^^ method not found in `QCellOwnerPinned`

--- a/src/compiletest/qcell_noalloc-05.stderr
+++ b/src/compiletest/qcell_noalloc-05.stderr
@@ -1,0 +1,14 @@
+error[E0599]: the method `clone` exists for struct `Pin<&mut QCellOwnerPinned>`, but its trait bounds were not satisfied
+   --> src/compiletest/qcell_noalloc-05.rs:10:25
+    |
+10  |     let owner2 = owner1.clone();  // Compile fail
+    |                         ^^^^^ method cannot be called on `Pin<&mut QCellOwnerPinned>` due to unsatisfied trait bounds
+    |
+   ::: $RUST/core/src/pin.rs
+    |
+    | pub struct Pin<P> {
+    | ----------------- doesn't satisfy `Pin<&mut QCellOwnerPinned>: Clone`
+    |
+    = note: the following trait bounds were not satisfied:
+            `&mut QCellOwnerPinned: Clone`
+            which is required by `Pin<&mut QCellOwnerPinned>: Clone`

--- a/src/compiletest/qcell_noalloc-06.stderr
+++ b/src/compiletest/qcell_noalloc-06.stderr
@@ -1,0 +1,9 @@
+error[E0499]: cannot borrow `owner` as mutable more than once at a time
+  --> src/compiletest/qcell_noalloc-06.rs:14:20
+   |
+13 |     let c1mutref = owner.as_mut().rw(&c1);
+   |                    -------------- first mutable borrow occurs here
+14 |     let c2mutref=  owner.as_mut().rw(&c2);  // Compile error
+   |                    ^^^^^^^^^^^^^^ second mutable borrow occurs here
+15 |     *c1mutref += 1;
+   |     -------------- first borrow later used here

--- a/src/compiletest/qcell_noalloc-07.stderr
+++ b/src/compiletest/qcell_noalloc-07.stderr
@@ -1,0 +1,9 @@
+error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
+  --> src/compiletest/qcell_noalloc-07.rs:13:20
+   |
+12 |     let c1ref = owner.as_ref().ro(&c1);
+   |                 -------------- immutable borrow occurs here
+13 |     let c1mutref = owner.as_mut().rw(&c1);    // Compile error
+   |                    ^^^^^^^^^^^^^^ mutable borrow occurs here
+14 |     println!("{}", *c1ref);
+   |                    ------ immutable borrow later used here

--- a/src/compiletest/qcell_noalloc-08.stderr
+++ b/src/compiletest/qcell_noalloc-08.stderr
@@ -1,0 +1,9 @@
+error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
+  --> src/compiletest/qcell_noalloc-08.rs:13:17
+   |
+12 |     let c1mutref = owner.as_mut().rw(&c1);
+   |                    -------------- mutable borrow occurs here
+13 |     let c2ref = owner.as_ref().ro(&c2);    // Compile error
+   |                 ^^^^^^^^^^^^^^ immutable borrow occurs here
+14 |     *c1mutref += 1;
+   |     -------------- mutable borrow later used here

--- a/src/compiletest/qcell_noalloc-09.stderr
+++ b/src/compiletest/qcell_noalloc-09.stderr
@@ -1,0 +1,9 @@
+error[E0505]: cannot move out of `c1` because it is borrowed
+  --> src/compiletest/qcell_noalloc-09.rs:13:10
+   |
+12 |     let c1ref = owner.as_ref().ro(&c1);
+   |                                   --- borrow of `c1` occurs here
+13 |     drop(c1);    // Compile error
+   |          ^^ move out of `c1` occurs here
+14 |     println!("{}", *c1ref);
+   |                    ------ borrow later used here

--- a/src/compiletest/qcell_noalloc-10.stderr
+++ b/src/compiletest/qcell_noalloc-10.stderr
@@ -1,0 +1,9 @@
+error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
+  --> src/compiletest/qcell_noalloc-10.rs:15:10
+   |
+14 |     let c1ref = owner.as_ref().ro(&c1);
+   |                 -------------- immutable borrow occurs here
+15 |     test(owner.as_mut());    // Compile error
+   |          ^^^^^^^^^^^^^^ mutable borrow occurs here
+16 |     println!("{}", *c1ref);
+   |                    ------ immutable borrow later used here

--- a/src/compiletest/qcell_noalloc-11.stderr
+++ b/src/compiletest/qcell_noalloc-11.stderr
@@ -1,0 +1,9 @@
+error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
+  --> src/compiletest/qcell_noalloc-11.rs:15:10
+   |
+14 |     let c1mutref = owner.as_mut().rw(&c1);
+   |                    -------------- mutable borrow occurs here
+15 |     test(owner.as_ref());    // Compile error
+   |          ^^^^^^^^^^^^^^ immutable borrow occurs here
+16 |     *c1mutref += 1;
+   |     -------------- mutable borrow later used here

--- a/src/compiletest/qcell_noalloc-12.stderr
+++ b/src/compiletest/qcell_noalloc-12.stderr
@@ -1,0 +1,25 @@
+error[E0505]: cannot move out of `owner` because it is borrowed
+  --> src/compiletest/qcell_noalloc-12.rs:9:24
+   |
+8  |     let val_ref = owner.as_ref().ro(&cell);
+   |                   -------------- borrow of `owner` occurs here
+9  |     std::thread::spawn(move || {
+   |                        ^^^^^^^ move out of `owner` occurs here
+10 |         assert_eq!(*owner.as_ref().ro(&cell), 100);
+   |                     ----- move occurs due to use in closure
+11 |     }).join();
+12 |     assert_eq!(*val_ref, 100);
+   |     ------------------------- borrow later used here
+
+error[E0505]: cannot move out of `cell` because it is borrowed
+  --> src/compiletest/qcell_noalloc-12.rs:9:24
+   |
+8  |     let val_ref = owner.as_ref().ro(&cell);
+   |                                     ----- borrow of `cell` occurs here
+9  |     std::thread::spawn(move || {
+   |                        ^^^^^^^ move out of `cell` occurs here
+10 |         assert_eq!(*owner.as_ref().ro(&cell), 100);
+   |                                        ---- move occurs due to use in closure
+11 |     }).join();
+12 |     assert_eq!(*val_ref, 100);
+   |     ------------------------- borrow later used here

--- a/src/compiletest/qcell_noalloc-13.stderr
+++ b/src/compiletest/qcell_noalloc-13.stderr
@@ -1,0 +1,13 @@
+error[E0277]: `Cell<i32>` cannot be shared between threads safely
+ --> src/compiletest/qcell_noalloc-13.rs:8:5
+  |
+8 |     is_sync::<QCell<Cell<i32>>>();  // Compile fail
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
+  |
+  = help: the trait `Sync` is not implemented for `Cell<i32>`
+  = note: required because of the requirements on the impl of `Sync` for `QCell<Cell<i32>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/qcell_noalloc-13.rs:7:19
+  |
+7 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/qcell_noalloc-14.stderr
+++ b/src/compiletest/qcell_noalloc-14.stderr
@@ -1,0 +1,27 @@
+error[E0277]: `Rc<()>` cannot be sent between threads safely
+ --> src/compiletest/qcell_noalloc-14.rs:8:5
+  |
+8 |     is_sync::<QCell<Rc<()>>>();  // Compile fail
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
+  |
+  = help: the trait `Send` is not implemented for `Rc<()>`
+  = note: required because of the requirements on the impl of `Sync` for `QCell<Rc<()>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/qcell_noalloc-14.rs:7:19
+  |
+7 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`
+
+error[E0277]: `Rc<()>` cannot be shared between threads safely
+ --> src/compiletest/qcell_noalloc-14.rs:8:5
+  |
+8 |     is_sync::<QCell<Rc<()>>>();  // Compile fail
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be shared between threads safely
+  |
+  = help: the trait `Sync` is not implemented for `Rc<()>`
+  = note: required because of the requirements on the impl of `Sync` for `QCell<Rc<()>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/qcell_noalloc-14.rs:7:19
+  |
+7 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/qcell_noalloc-15.stderr
+++ b/src/compiletest/qcell_noalloc-15.stderr
@@ -1,0 +1,14 @@
+error[E0277]: `Rc<()>` cannot be sent between threads safely
+ --> src/compiletest/qcell_noalloc-15.rs:8:5
+  |
+8 |     is_send::<QCell<Rc<()>>>();  // Compile fail
+  |     ^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
+  |
+  = help: within `QCell<Rc<()>>`, the trait `Send` is not implemented for `Rc<()>`
+  = note: required because it appears within the type `UnsafeCell<Rc<()>>`
+  = note: required because it appears within the type `QCell<Rc<()>>`
+note: required by a bound in `is_send`
+ --> src/compiletest/qcell_noalloc-15.rs:7:19
+  |
+7 |     fn is_send<T: Send>() {}
+  |                   ^^^^ required by this bound in `is_send`

--- a/src/compiletest/qcell_noalloc-16.stderr
+++ b/src/compiletest/qcell_noalloc-16.stderr
@@ -1,0 +1,20 @@
+error[E0277]: `Rc<i32>` cannot be sent between threads safely
+   --> src/compiletest/qcell_noalloc-16.rs:11:5
+    |
+11  |       std::thread::spawn(move || {    // Compile fail
+    |  _____^^^^^^^^^^^^^^^^^^_-
+    | |     |
+    | |     `Rc<i32>` cannot be sent between threads safely
+12  | |         assert_eq!(100, **owner.as_ref().ro(&cell));
+13  | |     }).join();
+    | |_____- within this `[closure@$DIR/src/compiletest/qcell_noalloc-16.rs:11:24: 13:6]`
+    |
+    = help: within `[closure@$DIR/src/compiletest/qcell_noalloc-16.rs:11:24: 13:6]`, the trait `Send` is not implemented for `Rc<i32>`
+    = note: required because it appears within the type `UnsafeCell<Rc<i32>>`
+    = note: required because it appears within the type `QCell<Rc<i32>>`
+    = note: required because it appears within the type `[closure@$DIR/src/compiletest/qcell_noalloc-16.rs:11:24: 13:6]`
+note: required by a bound in `spawn`
+   --> $RUST/std/src/thread/mod.rs
+    |
+    |     F: Send + 'static,
+    |        ^^^^ required by this bound in `spawn`

--- a/src/compiletest/tcell-00.stderr
+++ b/src/compiletest/tcell-00.stderr
@@ -1,9 +1,9 @@
 error[E0382]: borrow of moved value: `owner1`
-  --> $DIR/tcell-00.rs:12:22
+  --> src/compiletest/tcell-00.rs:12:22
    |
 10 |     let mut owner1 = ACellOwner::new();
    |         ---------- move occurs because `owner1` has type `TCellOwner<Marker>`, which does not implement the `Copy` trait
 11 |     let mut owner2 = owner1;
    |                      ------ value moved here
 12 |     let rc = Rc::new(owner1.cell(100u32));  // Compile fail
-   |                      ^^^^^^ value borrowed here after move
+   |                      ^^^^^^^^^^^^^^^^^^^ value borrowed here after move

--- a/src/compiletest/tcell-04.stderr
+++ b/src/compiletest/tcell-04.stderr
@@ -1,9 +1,9 @@
 error[E0499]: cannot borrow `owner` as mutable more than once at a time
-  --> $DIR/tcell-04.rs:15:20
+  --> src/compiletest/tcell-04.rs:15:20
    |
 14 |     let c1mutref = owner.rw(&c1);
-   |                    ----- first mutable borrow occurs here
+   |                    ------------- first mutable borrow occurs here
 15 |     let c2mutref = owner.rw(&c2);  // Compile error
-   |                    ^^^^^ second mutable borrow occurs here
+   |                    ^^^^^^^^^^^^^ second mutable borrow occurs here
 16 |     *c1mutref += 1;
    |     -------------- first borrow later used here

--- a/src/compiletest/tcell-05.stderr
+++ b/src/compiletest/tcell-05.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
-  --> $DIR/tcell-05.rs:15:20
+  --> src/compiletest/tcell-05.rs:15:20
    |
 14 |     let c1ref = owner.ro(&c1);
-   |                 ----- immutable borrow occurs here
+   |                 ------------- immutable borrow occurs here
 15 |     let c1mutref = owner.rw(&c1);    // Compile error
    |                    ^^^^^^^^^^^^^ mutable borrow occurs here
 16 |     println!("{}", *c1ref);

--- a/src/compiletest/tcell-06.stderr
+++ b/src/compiletest/tcell-06.stderr
@@ -1,9 +1,9 @@
 error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
-  --> $DIR/tcell-06.rs:15:17
+  --> src/compiletest/tcell-06.rs:15:17
    |
 14 |     let c1mutref = owner.rw(&c1);
-   |                    ----- mutable borrow occurs here
+   |                    ------------- mutable borrow occurs here
 15 |     let c2ref = owner.ro(&c2);    // Compile error
-   |                 ^^^^^ immutable borrow occurs here
+   |                 ^^^^^^^^^^^^^ immutable borrow occurs here
 16 |     *c1mutref += 1;
    |     -------------- mutable borrow later used here

--- a/src/compiletest/tcell-08.stderr
+++ b/src/compiletest/tcell-08.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
-  --> $DIR/tcell-08.rs:17:10
+  --> src/compiletest/tcell-08.rs:17:10
    |
 16 |     let c1ref = owner.ro(&c1);
-   |                 ----- immutable borrow occurs here
+   |                 ------------- immutable borrow occurs here
 17 |     test(&mut owner);    // Compile error
    |          ^^^^^^^^^^ mutable borrow occurs here
 18 |     println!("{}", *c1ref);

--- a/src/compiletest/tcell-09.stderr
+++ b/src/compiletest/tcell-09.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
-  --> $DIR/tcell-09.rs:17:10
+  --> src/compiletest/tcell-09.rs:17:10
    |
 16 |     let c1mutref = owner.rw(&c1);
-   |                    ----- mutable borrow occurs here
+   |                    ------------- mutable borrow occurs here
 17 |     test(&owner);    // Compile error
    |          ^^^^^^ immutable borrow occurs here
 18 |     *c1mutref += 1;

--- a/src/compiletest/tcell-10.stderr
+++ b/src/compiletest/tcell-10.stderr
@@ -1,18 +1,18 @@
 error[E0505]: cannot move out of `owner` because it is borrowed
-  --> $DIR/tcell-10.rs:12:24
+  --> src/compiletest/tcell-10.rs:12:24
    |
 11 |     let val_ref = owner.ro(&cell);
-   |                   ----- borrow of `owner` occurs here
+   |                   --------------- borrow of `owner` occurs here
 12 |     std::thread::spawn(move || {
    |                        ^^^^^^^ move out of `owner` occurs here
 13 |         assert_eq!(*owner.ro(&cell), 100);
    |                     ----- move occurs due to use in closure
 14 |     }).join();
 15 |     assert_eq!(*val_ref, 100);
-   |     -------------------------- borrow later used here
+   |     ------------------------- borrow later used here
 
 error[E0505]: cannot move out of `cell` because it is borrowed
-  --> $DIR/tcell-10.rs:12:24
+  --> src/compiletest/tcell-10.rs:12:24
    |
 11 |     let val_ref = owner.ro(&cell);
    |                            ----- borrow of `cell` occurs here
@@ -22,4 +22,4 @@ error[E0505]: cannot move out of `cell` because it is borrowed
    |                               ---- move occurs due to use in closure
 14 |     }).join();
 15 |     assert_eq!(*val_ref, 100);
-   |     -------------------------- borrow later used here
+   |     ------------------------- borrow later used here

--- a/src/compiletest/tcell-11.stderr
+++ b/src/compiletest/tcell-11.stderr
@@ -1,10 +1,13 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
- --> $DIR/tcell-11.rs:9:5
+ --> src/compiletest/tcell-11.rs:9:5
   |
-8 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
 9 |     is_sync::<TCell<Marker, Cell<i32>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
   |
   = help: the trait `Sync` is not implemented for `Cell<i32>`
   = note: required because of the requirements on the impl of `Sync` for `TCell<Marker, Cell<i32>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/tcell-11.rs:8:19
+  |
+8 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/tcell-12.stderr
+++ b/src/compiletest/tcell-12.stderr
@@ -1,15 +1,15 @@
 error[E0277]: `Cell<i32>` cannot be shared between threads safely
-   --> $DIR/tcell-12.rs:15:5
+   --> src/compiletest/tcell-12.rs:15:5
     |
 15  |     std::thread::spawn(|| owner.ro(&cell).set(200));  // Compile fail
     |     ^^^^^^^^^^^^^^^^^^ `Cell<i32>` cannot be shared between threads safely
-    |
-   ::: $RUST/std/src/thread/mod.rs
-    |
-    |     F: Send + 'static,
-    |        ---- required by this bound in `spawn`
     |
     = help: the trait `Sync` is not implemented for `Cell<i32>`
     = note: required because of the requirements on the impl of `Sync` for `TCell<Marker, Cell<i32>>`
     = note: required because of the requirements on the impl of `Send` for `&TCell<Marker, Cell<i32>>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tcell-12.rs:15:24: 15:51]`
+note: required by a bound in `spawn`
+   --> $RUST/std/src/thread/mod.rs
+    |
+    |     F: Send + 'static,
+    |        ^^^^ required by this bound in `spawn`

--- a/src/compiletest/tcell-13.stderr
+++ b/src/compiletest/tcell-13.stderr
@@ -1,21 +1,27 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
- --> $DIR/tcell-13.rs:9:5
+ --> src/compiletest/tcell-13.rs:9:5
   |
-8 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
 9 |     is_sync::<TCell<Marker, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
   = help: the trait `Send` is not implemented for `Rc<()>`
   = note: required because of the requirements on the impl of `Sync` for `TCell<Marker, Rc<()>>`
-
-error[E0277]: `Rc<()>` cannot be shared between threads safely
- --> $DIR/tcell-13.rs:9:5
+note: required by a bound in `is_sync`
+ --> src/compiletest/tcell-13.rs:8:19
   |
 8 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
+  |                   ^^^^ required by this bound in `is_sync`
+
+error[E0277]: `Rc<()>` cannot be shared between threads safely
+ --> src/compiletest/tcell-13.rs:9:5
+  |
 9 |     is_sync::<TCell<Marker, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be shared between threads safely
   |
   = help: the trait `Sync` is not implemented for `Rc<()>`
   = note: required because of the requirements on the impl of `Sync` for `TCell<Marker, Rc<()>>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/tcell-13.rs:8:19
+  |
+8 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/tcell-14.stderr
+++ b/src/compiletest/tcell-14.stderr
@@ -1,11 +1,14 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
- --> $DIR/tcell-14.rs:9:5
+ --> src/compiletest/tcell-14.rs:9:5
   |
-8 |     fn is_send<T: Send>() {}
-  |                   ---- required by this bound in `is_send`
 9 |     is_send::<TCell<Marker, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
   = help: within `TCell<Marker, Rc<()>>`, the trait `Send` is not implemented for `Rc<()>`
   = note: required because it appears within the type `UnsafeCell<Rc<()>>`
   = note: required because it appears within the type `TCell<Marker, Rc<()>>`
+note: required by a bound in `is_send`
+ --> src/compiletest/tcell-14.rs:8:19
+  |
+8 |     fn is_send<T: Send>() {}
+  |                   ^^^^ required by this bound in `is_send`

--- a/src/compiletest/tcell-15.stderr
+++ b/src/compiletest/tcell-15.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `Rc<i32>` cannot be sent between threads safely
-   --> $DIR/tcell-15.rs:15:5
+   --> src/compiletest/tcell-15.rs:15:5
     |
 15  |       std::thread::spawn(move || {    // Compile fail
     |  _____^^^^^^^^^^^^^^^^^^_-
@@ -9,12 +9,12 @@ error[E0277]: `Rc<i32>` cannot be sent between threads safely
 17  | |     }).join();
     | |_____- within this `[closure@$DIR/src/compiletest/tcell-15.rs:15:24: 17:6]`
     |
-   ::: $RUST/std/src/thread/mod.rs
-    |
-    |       F: Send + 'static,
-    |          ---- required by this bound in `spawn`
-    |
     = help: within `[closure@$DIR/src/compiletest/tcell-15.rs:15:24: 17:6]`, the trait `Send` is not implemented for `Rc<i32>`
     = note: required because it appears within the type `UnsafeCell<Rc<i32>>`
     = note: required because it appears within the type `TCell<Marker, Rc<i32>>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tcell-15.rs:15:24: 17:6]`
+note: required by a bound in `spawn`
+   --> $RUST/std/src/thread/mod.rs
+    |
+    |     F: Send + 'static,
+    |        ^^^^ required by this bound in `spawn`

--- a/src/compiletest/tcell-16.rs
+++ b/src/compiletest/tcell-16.rs
@@ -5,7 +5,7 @@ fn main() {
     use qcell::{TCell, TCellOwner};
     type MarkerA = fn(&());
     type MarkerB = fn(&'static ());
-
+   
     let mut owner1 = TCellOwner::<MarkerA>::new() as TCellOwner<MarkerB>;  // Compile fail
     let mut owner2 = TCellOwner::<MarkerB>::new();
     let cell = TCell::<MarkerB, u32>::new(1234);

--- a/src/compiletest/tcell-16.stderr
+++ b/src/compiletest/tcell-16.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/tcell-16.rs:9:22
+ --> src/compiletest/tcell-16.rs:9:22
   |
 9 |     let mut owner1 = TCellOwner::<MarkerA>::new() as TCellOwner<MarkerB>;  // Compile fail
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other

--- a/src/compiletest/tlcell-00.stderr
+++ b/src/compiletest/tlcell-00.stderr
@@ -1,9 +1,9 @@
 error[E0382]: borrow of moved value: `owner1`
-  --> $DIR/tlcell-00.rs:12:22
+  --> src/compiletest/tlcell-00.rs:12:22
    |
 10 |     let mut owner1 = ACellOwner::new();
    |         ---------- move occurs because `owner1` has type `TLCellOwner<Marker>`, which does not implement the `Copy` trait
 11 |     let mut owner2 = owner1;
    |                      ------ value moved here
 12 |     let rc = Rc::new(owner1.cell(100u32));  // Compile fail
-   |                      ^^^^^^ value borrowed here after move
+   |                      ^^^^^^^^^^^^^^^^^^^ value borrowed here after move

--- a/src/compiletest/tlcell-04.stderr
+++ b/src/compiletest/tlcell-04.stderr
@@ -1,9 +1,9 @@
 error[E0499]: cannot borrow `owner` as mutable more than once at a time
-  --> $DIR/tlcell-04.rs:15:20
+  --> src/compiletest/tlcell-04.rs:15:20
    |
 14 |     let c1mutref = owner.rw(&c1);
-   |                    ----- first mutable borrow occurs here
+   |                    ------------- first mutable borrow occurs here
 15 |     let c2mutref = owner.rw(&c2);  // Compile error
-   |                    ^^^^^ second mutable borrow occurs here
+   |                    ^^^^^^^^^^^^^ second mutable borrow occurs here
 16 |     *c1mutref += 1;
    |     -------------- first borrow later used here

--- a/src/compiletest/tlcell-05.stderr
+++ b/src/compiletest/tlcell-05.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
-  --> $DIR/tlcell-05.rs:15:20
+  --> src/compiletest/tlcell-05.rs:15:20
    |
 14 |     let c1ref = owner.ro(&c1);
-   |                 ----- immutable borrow occurs here
+   |                 ------------- immutable borrow occurs here
 15 |     let c1mutref = owner.rw(&c1);    // Compile error
    |                    ^^^^^^^^^^^^^ mutable borrow occurs here
 16 |     println!("{}", *c1ref);

--- a/src/compiletest/tlcell-06.stderr
+++ b/src/compiletest/tlcell-06.stderr
@@ -1,9 +1,9 @@
 error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
-  --> $DIR/tlcell-06.rs:15:17
+  --> src/compiletest/tlcell-06.rs:15:17
    |
 14 |     let c1mutref = owner.rw(&c1);
-   |                    ----- mutable borrow occurs here
+   |                    ------------- mutable borrow occurs here
 15 |     let c2ref = owner.ro(&c2);    // Compile error
-   |                 ^^^^^ immutable borrow occurs here
+   |                 ^^^^^^^^^^^^^ immutable borrow occurs here
 16 |     *c1mutref += 1;
    |     -------------- mutable borrow later used here

--- a/src/compiletest/tlcell-08.stderr
+++ b/src/compiletest/tlcell-08.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as mutable because it is also borrowed as immutable
-  --> $DIR/tlcell-08.rs:17:10
+  --> src/compiletest/tlcell-08.rs:17:10
    |
 16 |     let c1ref = owner.ro(&c1);
-   |                 ----- immutable borrow occurs here
+   |                 ------------- immutable borrow occurs here
 17 |     test(&mut owner);    // Compile error
    |          ^^^^^^^^^^ mutable borrow occurs here
 18 |     println!("{}", *c1ref);

--- a/src/compiletest/tlcell-09.stderr
+++ b/src/compiletest/tlcell-09.stderr
@@ -1,8 +1,8 @@
 error[E0502]: cannot borrow `owner` as immutable because it is also borrowed as mutable
-  --> $DIR/tlcell-09.rs:17:10
+  --> src/compiletest/tlcell-09.rs:17:10
    |
 16 |     let c1mutref = owner.rw(&c1);
-   |                    ----- mutable borrow occurs here
+   |                    ------------- mutable borrow occurs here
 17 |     test(&owner);    // Compile error
    |          ^^^^^^ immutable borrow occurs here
 18 |     *c1mutref += 1;

--- a/src/compiletest/tlcell-10.stderr
+++ b/src/compiletest/tlcell-10.stderr
@@ -1,8 +1,6 @@
 error[E0277]: `*const ()` cannot be sent between threads safely
- --> $DIR/tlcell-10.rs:8:5
+ --> src/compiletest/tlcell-10.rs:8:5
   |
-7 |     fn is_send<T: Send>() {}
-  |                   ---- required by this bound in `is_send`
 8 |     is_send::<TLCellOwner<Marker>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be sent between threads safely
   |
@@ -10,3 +8,8 @@ error[E0277]: `*const ()` cannot be sent between threads safely
   = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
   = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
   = note: required because it appears within the type `TLCellOwner<Marker>`
+note: required by a bound in `is_send`
+ --> src/compiletest/tlcell-10.rs:7:19
+  |
+7 |     fn is_send<T: Send>() {}
+  |                   ^^^^ required by this bound in `is_send`

--- a/src/compiletest/tlcell-11.stderr
+++ b/src/compiletest/tlcell-11.stderr
@@ -1,8 +1,6 @@
 error[E0277]: `*const ()` cannot be shared between threads safely
- --> $DIR/tlcell-11.rs:8:5
+ --> src/compiletest/tlcell-11.rs:8:5
   |
-7 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
 8 |     is_sync::<TLCellOwner<Marker>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `*const ()` cannot be shared between threads safely
   |
@@ -10,3 +8,8 @@ error[E0277]: `*const ()` cannot be shared between threads safely
   = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
   = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
   = note: required because it appears within the type `TLCellOwner<Marker>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/tlcell-11.rs:7:19
+  |
+7 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/tlcell-12.stderr
+++ b/src/compiletest/tlcell-12.stderr
@@ -1,10 +1,13 @@
 error[E0277]: `UnsafeCell<()>` cannot be shared between threads safely
- --> $DIR/tlcell-12.rs:8:5
+ --> src/compiletest/tlcell-12.rs:8:5
   |
-7 |     fn is_sync<T: Sync>() {}
-  |                   ---- required by this bound in `is_sync`
 8 |     is_sync::<TLCell<Marker, ()>>(); // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `UnsafeCell<()>` cannot be shared between threads safely
   |
   = help: within `TLCell<Marker, ()>`, the trait `Sync` is not implemented for `UnsafeCell<()>`
   = note: required because it appears within the type `TLCell<Marker, ()>`
+note: required by a bound in `is_sync`
+ --> src/compiletest/tlcell-12.rs:7:19
+  |
+7 |     fn is_sync<T: Sync>() {}
+  |                   ^^^^ required by this bound in `is_sync`

--- a/src/compiletest/tlcell-13.stderr
+++ b/src/compiletest/tlcell-13.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `*const ()` cannot be sent between threads safely
-   --> $DIR/tlcell-13.rs:12:5
+   --> src/compiletest/tlcell-13.rs:12:5
     |
 12  |       std::thread::spawn(move || {
     |  _____^^^^^^^^^^^^^^^^^^_-
@@ -9,13 +9,13 @@ error[E0277]: `*const ()` cannot be sent between threads safely
 14  | |     }).join();
     | |_____- within this `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`
     |
-   ::: $RUST/std/src/thread/mod.rs
-    |
-    |       F: Send + 'static,
-    |          ---- required by this bound in `spawn`
-    |
     = help: within `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`, the trait `Send` is not implemented for `*const ()`
     = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
     = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
     = note: required because it appears within the type `TLCellOwner<Marker>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-13.rs:12:24: 14:6]`
+note: required by a bound in `spawn`
+   --> $RUST/std/src/thread/mod.rs
+    |
+    |     F: Send + 'static,
+    |        ^^^^ required by this bound in `spawn`

--- a/src/compiletest/tlcell-14.stderr
+++ b/src/compiletest/tlcell-14.stderr
@@ -1,11 +1,14 @@
 error[E0277]: `Rc<()>` cannot be sent between threads safely
- --> $DIR/tlcell-14.rs:9:5
+ --> src/compiletest/tlcell-14.rs:9:5
   |
-8 |     fn is_send<T: Send>() {}
-  |                   ---- required by this bound in `is_send`
 9 |     is_send::<TLCell<Marker, Rc<()>>>();  // Compile fail
   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ `Rc<()>` cannot be sent between threads safely
   |
   = help: within `TLCell<Marker, Rc<()>>`, the trait `Send` is not implemented for `Rc<()>`
   = note: required because it appears within the type `UnsafeCell<Rc<()>>`
   = note: required because it appears within the type `TLCell<Marker, Rc<()>>`
+note: required by a bound in `is_send`
+ --> src/compiletest/tlcell-14.rs:8:19
+  |
+8 |     fn is_send<T: Send>() {}
+  |                   ^^^^ required by this bound in `is_send`

--- a/src/compiletest/tlcell-15.stderr
+++ b/src/compiletest/tlcell-15.stderr
@@ -1,5 +1,5 @@
 error[E0277]: `Rc<i32>` cannot be sent between threads safely
-   --> $DIR/tlcell-15.rs:15:5
+   --> src/compiletest/tlcell-15.rs:15:5
     |
 15  |       std::thread::spawn(move || {    // Compile fail
     |  _____^^^^^^^^^^^^^^^^^^_-
@@ -9,18 +9,18 @@ error[E0277]: `Rc<i32>` cannot be sent between threads safely
 17  | |     }).join();
     | |_____- within this `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`
     |
-   ::: $RUST/std/src/thread/mod.rs
-    |
-    |       F: Send + 'static,
-    |          ---- required by this bound in `spawn`
-    |
     = help: within `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`, the trait `Send` is not implemented for `Rc<i32>`
     = note: required because it appears within the type `UnsafeCell<Rc<i32>>`
     = note: required because it appears within the type `TLCell<Marker, Rc<i32>>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`
+note: required by a bound in `spawn`
+   --> $RUST/std/src/thread/mod.rs
+    |
+    |     F: Send + 'static,
+    |        ^^^^ required by this bound in `spawn`
 
 error[E0277]: `*const ()` cannot be sent between threads safely
-   --> $DIR/tlcell-15.rs:15:5
+   --> src/compiletest/tlcell-15.rs:15:5
     |
 15  |       std::thread::spawn(move || {    // Compile fail
     |  _____^^^^^^^^^^^^^^^^^^_-
@@ -30,13 +30,13 @@ error[E0277]: `*const ()` cannot be sent between threads safely
 17  | |     }).join();
     | |_____- within this `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`
     |
-   ::: $RUST/std/src/thread/mod.rs
-    |
-    |       F: Send + 'static,
-    |          ---- required by this bound in `spawn`
-    |
     = help: within `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`, the trait `Send` is not implemented for `*const ()`
     = note: required because it appears within the type `qcell::tlcell::NotSendOrSync`
     = note: required because it appears within the type `PhantomData<qcell::tlcell::NotSendOrSync>`
     = note: required because it appears within the type `TLCellOwner<Marker>`
     = note: required because it appears within the type `[closure@$DIR/src/compiletest/tlcell-15.rs:15:24: 17:6]`
+note: required by a bound in `spawn`
+   --> $RUST/std/src/thread/mod.rs
+    |
+    |     F: Send + 'static,
+    |        ^^^^ required by this bound in `spawn`

--- a/src/compiletest/tlcell-16.rs
+++ b/src/compiletest/tlcell-16.rs
@@ -5,7 +5,7 @@ fn main() {
     use qcell::{TLCell, TLCellOwner};
     type MarkerA = fn(&());
     type MarkerB = fn(&'static ());
-
+   
     let mut owner1 = TLCellOwner::<MarkerA>::new() as TLCellOwner<MarkerB>;  // Compile fail
     let mut owner2 = TLCellOwner::<MarkerB>::new();
     let cell = TLCell::<MarkerB, u32>::new(1234);

--- a/src/compiletest/tlcell-16.stderr
+++ b/src/compiletest/tlcell-16.stderr
@@ -1,5 +1,5 @@
 error[E0308]: mismatched types
- --> $DIR/tlcell-16.rs:9:22
+ --> src/compiletest/tlcell-16.rs:9:22
   |
 9 |     let mut owner1 = TLCellOwner::<MarkerA>::new() as TLCellOwner<MarkerB>;  // Compile fail
   |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ one type is more general than the other

--- a/src/doctest_qcell_noalloc.rs
+++ b/src/doctest_qcell_noalloc.rs
@@ -1,7 +1,7 @@
 // Run ./update-compiletest-from-doctest.pl in crate base directory
 // after making any modification to compile_fail tests here.
 
-//! Tests for QCell functionality without `alloc` feature enabled.
+//! This tests the `QCell` implementation without the `alloc` feature.
 //!
 //! You should not be able to use QCellOwnerPinned without pinning it first
 //!
@@ -230,13 +230,12 @@
 //! *c1mutref += 1;
 //! ```
 //!
-//! `QCellOwner`, `QCellOwnerPinned`, and `QCell` should be both
+//! `QCellOwnerPinned` and `QCell` should be both
 //! `Send` and `Sync` by default:
 //!
 //! ```
-//!# use qcell::{QCellOwner, QCell, QCellOwnerPinned};
+//!# use qcell::{QCell, QCellOwnerPinned};
 //! fn is_send_sync<T: Send + Sync>() {}
-//! is_send_sync::<QCellOwner>();
 //! is_send_sync::<QCellOwnerPinned>();
 //! is_send_sync::<QCell<()>>();
 //! ```


### PR DESCRIPTION
- Split out QCellOwnerSeq from QCellOwner::fast_new
- Tidy up qcell.rs loose ends
- Polish up docs and examples
- CHANGELOG update
- Scripts for running clippy/doc/tests with all feature combinations
- Update compiletests
