### PR TITLE
Enable generativity feature for `LCellOwner`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ alloc = []
 
 [dependencies]
 once_cell = { version = "1.4.0", optional = true }
+generativity = { version = "1.0.0", optional = true }
 
 [dev-dependencies]
 crossbeam = "0.7"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -375,6 +375,9 @@ pub mod doctest_tcell;
 #[cfg(feature = "std")]
 pub mod doctest_tlcell;
 
+#[cfg(feature = "generativity")]
+pub extern crate generativity;
+
 // Used in LCell, TCell and TLCell.  See the Rustonomicon chapters
 // "Subtyping and Variance"
 // (https://doc.rust-lang.org/nomicon/subtyping.html) and

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -361,12 +361,10 @@ mod tests {
                 val
             });
 
-            match done_rx.recv_timeout(d) {
-                Ok(_) => panic!("ACellOwner::wait_for_new completed (but it shouldn't have)"),
-                Err(_) => {
-                    // thread timed out as expected
-                }
-            }
+            assert!(
+                done_rx.recv_timeout(d).is_err(),
+                "ACellOwner::wait_for_new completed (but it shouldn't have)"
+            );
         }
 
         assert_time_out(std::time::Duration::from_millis(1000), || {


### PR DESCRIPTION
Closes #31 

I was able to avoid the issue of conflicting implementation of `'id` by just reusing the lifetime in `PhantomData`. Let me know what you think of how I exported `generativity`. I added it as a namespace under `qcell`.

Also fixed a clippy lint.