### PR TITLE
Implement PartialEq and Eq for QCellOwnerID

### DIFF
--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -72,7 +72,7 @@ macro_rules! distinct_check {
 /// instances to be created after the owner has gone.  But [`QCell`]
 /// instances can outlive the owner in any case, so this makes no
 /// difference to safety.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, PartialEq, Eq)]
 pub struct QCellOwnerID(usize);
 
 impl QCellOwnerID {


### PR DESCRIPTION
I have a use case where QCells are used to manage the internal state of objects belonging to a particular "world", and mixing objects from different "worlds" is an error.

Checking the equality of `QCellOwnerID` allows me to catch errors without panicking, without introducing a separate "world ID" only for this purpose, and to provide better diagnostics to the user of my library.

As far as I can tell, there are no hazards associated with this change.