### PR TITLE
Implement Hash for QCellOwnerID

### DIFF
--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -72,7 +72,7 @@ macro_rules! distinct_check {
 /// instances to be created after the owner has gone.  But [`QCell`]
 /// instances can outlive the owner in any case, so this makes no
 /// difference to safety.
-#[derive(Clone, Copy, PartialEq, Eq)]
+#[derive(Clone, Copy, PartialEq, Eq, Hash)]
 pub struct QCellOwnerID(usize);
 
 impl QCellOwnerID {


### PR DESCRIPTION
This allows a `QCellOwnerID` to be used as the key of a `HashMap`. There appears to be some demand for cell-owners-as-keys, e.g., in the [`guest_cell`](https://crates.io/crates/guest_cell) crate. This exposes the `usize`, but that shouldn't cause any soundness issue, since there's no sound way to convert it back to a `QCellOwnerID`.