### PR TITLE
Optional dependancy on exclusion-set for no_std TCell

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,13 @@ categories = [ "data-structures", "memory-management", "rust-patterns" ]
 
 [features]
 default = ["std"]
-std = ["alloc", "once_cell"]
+std = ["alloc", "once_cell", "exclusion-set?/std"]
 alloc = []
 
 [dependencies]
 once_cell = { version = "1.4.0", optional = true }
 generativity = { version = "1.0.0", optional = true }
+exclusion-set = { version = "0.1.2", optional = true }
 
 [dev-dependencies]
 crossbeam = "0.8"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@ name = "qcell"
 version = "0.5.3"
 authors = ["Jim Peters <jim@uazu.net>"]
 edition = "2018"
+rust-version = "1.60.0"
 
 description = "Statically-checked alternatives to RefCell and RwLock"
 license = "MIT/Apache-2.0"

--- a/run-clippy-all
+++ b/run-clippy-all
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-cargo clippy &&
-cargo clippy --features generativity &&
-cargo clippy --no-default-features --features alloc &&
-cargo clippy --no-default-features
+./run-feature-combinations |
+    while read msrv features
+    do
+        echo "=== Features: $features"
+        cargo clippy --no-default-features --features "$features" || exit 1
+    done

--- a/run-clippy-all-msrv
+++ b/run-clippy-all-msrv
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+./run-feature-combinations |
+    while read msrv features
+    do
+        echo "=== $msrv: Features: $features"
+        cargo +$msrv clippy --no-default-features --features "$features" || exit 1
+    done

--- a/run-doc-all
+++ b/run-doc-all
@@ -5,8 +5,12 @@
 # no_std docs).  Then finally build as docs.rs sees it to visually
 # check the "std" and "alloc" annotations on some types.
 
-cargo doc &&
-cargo doc --features generativity &&
-cargo doc --no-default-features --features alloc &&
-cargo doc --no-default-features &&
+./run-feature-combinations |
+    while read msrv features
+    do
+        echo "=== Features: $features"
+        cargo doc --no-default-features --features "$features" || exit 1
+    done
+
+echo "=== Docs.rs output"
 RUSTDOCFLAGS="--cfg docsrs" cargo +nightly doc --all-features

--- a/run-feature-combinations
+++ b/run-feature-combinations
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# You can't have 'std' without 'alloc', since 'std' depends on it
+for a in '' 'alloc,' 'std,alloc,'; do
+    # These two affect independent sections of code so can be tested
+    # together
+    for b in '' 'generativity,exclusion-set,'; do
+        all="$a$b"
+        case "$all" in
+            *exclusion-set*) MSRV=1.65;;
+            *) MSRV=1.60;;
+        esac
+        echo "$MSRV ${all%,}"
+    done
+done

--- a/run-test-all
+++ b/run-test-all
@@ -1,6 +1,10 @@
 #!/bin/bash
 
-cargo test &&
-cargo test --features generativity &&
-cargo test --no-default-features --features alloc &&
-cargo test --no-default-features
+./run-feature-combinations |
+    while read msrv features
+    do
+        echo "=== Features: $features"
+        cargo test --no-default-features --features "$features" || exit 1
+    done
+
+echo SUCCESS

--- a/run-test-all-msrv
+++ b/run-test-all-msrv
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+./run-feature-combinations |
+    while read msrv features
+    do
+        echo "=== $msrv: Features: $features"
+        cargo +$msrv test --no-default-features --features "$features" || exit 1
+    done
+
+echo SUCCESS

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -365,7 +365,6 @@ extern crate alloc;
 
 mod lcell;
 mod qcell;
-#[cfg(feature = "std")]
 mod tcell;
 #[cfg(feature = "std")]
 mod tlcell;
@@ -411,12 +410,14 @@ pub use crate::qcell::QCell;
 pub use crate::qcell::QCellOwnerID;
 pub use crate::qcell::QCellOwnerPinned;
 pub use crate::qcell::QCellOwnerSeq;
+pub use crate::tcell::TCell;
+pub use crate::tcell::TCellOwner;
 
 #[cfg(feature = "alloc")]
 pub use crate::qcell::QCellOwner;
 
 #[cfg(feature = "std")]
-pub use crate::{tcell::TCell, tcell::TCellOwner, tlcell::TLCell, tlcell::TLCellOwner};
+pub use crate::{tlcell::TLCell, tlcell::TLCellOwner};
 
 // Static assertions on traits
 #[cfg(test)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -192,12 +192,12 @@
 //! - Pro: Compile-time borrowing checks
 //! - Pro: No overhead at runtime for borrowing or ownership checks
 //! - Pro: No cell space overhead
+//! - Pro: `no_std` support (via external crate)
 //! - Con: Can only borrow up to 3 objects at a time
 //! - Con: Uses singletons, either per-process (TCell) or per-thread
 //! (TLCell), meaning only one owner is allowed per thread or process
 //! per marker type.  Code intended to be nested on the call stack
 //! must be parameterised with an external marker type.
-//! - Con: Currently requires `std`
 //!
 //! [`LCell`] pros and cons:
 //!
@@ -313,16 +313,21 @@
 //!
 //! # `no_std` support
 //!
-//! There are three levels at which **qcell** crate can be built:
+//! There are four levels at which **qcell** crate can be built:
 //!
 //! - Full `std` support, which is the default
+//!
+//! - `no_std` with
+//! [**exclusion-set**](https://crates.io/crates/exclusion-set), when
+//! built with `--no-default-features` and `--features exclusion-set`
 //!
 //! - `no_std` with `alloc`, when built with `--no-default-features`
 //! and `--features alloc`
 //!
 //! - `no_std` without `alloc`, when built with `--no-default-features`
 //!
-//! Both [`QCell`] and [`LCell`] support all three levels.
+//! Both [`QCell`] and [`LCell`] support all four levels, and
+//! [`TCell`] is also available for the first two.
 //!
 //! # Origin of names
 //!

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -1,9 +1,13 @@
+use core::any::TypeId;
+use core::cell::UnsafeCell;
+use core::marker::PhantomData;
+#[cfg(all(feature = "std", not(feature = "exclusion-set")))]
 use once_cell::sync::Lazy;
-use std::any::TypeId;
-use std::cell::UnsafeCell;
-use std::collections::HashSet;
-use std::marker::PhantomData;
-use std::sync::{Condvar, Mutex};
+#[cfg(all(feature = "std", not(feature = "exclusion-set")))]
+use std::{
+    collections::HashSet,
+    sync::{Condvar, Mutex},
+};
 
 use super::Invariant;
 

--- a/src/tcell.rs
+++ b/src/tcell.rs
@@ -7,20 +7,24 @@ use std::sync::{Condvar, Mutex};
 
 use super::Invariant;
 
+#[cfg(all(feature = "std", not(feature = "exclusion-set")))]
 static SINGLETON_CHECK: Lazy<Mutex<HashSet<TypeId>>> = Lazy::new(|| Mutex::new(HashSet::new()));
+#[cfg(all(feature = "std", not(feature = "exclusion-set")))]
 static SINGLETON_CHECK_CONDVAR: Lazy<Condvar> = Lazy::new(Condvar::new);
+#[cfg(feature = "exclusion-set")]
+static SINGLETON_CHECK_SET: exclusion_set::Set<TypeId> = exclusion_set::Set::new();
 
 /// Borrowing-owner of zero or more [`TCell`](struct.TCell.html)
 /// instances.
 ///
 /// See [crate documentation](index.html).
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct TCellOwner<Q: 'static> {
     // Allow Send and Sync, and Q is invariant
     typ: PhantomData<Invariant<Q>>,
 }
 
 impl<Q: 'static> Drop for TCellOwner<Q> {
+    #[cfg(all(not(feature = "exclusion-set"), feature = "std"))]
     fn drop(&mut self) {
         // Remove the TypeId of Q from the HashSet, indicating that
         // no more instances of TCellOwner<Q> exist.
@@ -30,8 +34,28 @@ impl<Q: 'static> Drop for TCellOwner<Q> {
         // to check if their Q was removed from the HashSet.
         SINGLETON_CHECK_CONDVAR.notify_all();
     }
+
+    #[cfg(feature = "exclusion-set")]
+    fn drop(&mut self) {
+        // Remove the TypeId of Q from the Set, indicating that
+        // no more instances of TCellOwner<Q> exist.
+        // SAFETY: the precondition of remove is satisfied since
+        // this can be the only TCellOwner for a given Q.
+        unsafe {
+            SINGLETON_CHECK_SET.remove(&TypeId::of::<Q>());
+        }
+    }
+
+    #[cfg(not(any(feature = "std", feature = "exclusion-set")))]
+    fn drop(&mut self) {
+        // constructors should be unavailable with this feature set, so the
+        // destructor should be unreachable
+        unreachable!()
+    }
 }
 
+#[cfg(any(feature = "std", feature = "exclusion-set"))]
+#[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "exclusion-set"))))]
 impl<Q: 'static> Default for TCellOwner<Q> {
     fn default() -> Self {
         TCellOwner::new()
@@ -50,6 +74,8 @@ impl<Q: 'static> TCellOwner<Q> {
     /// this panic may be more easy to trigger than you might think.
     /// To avoid this panic, consider using the methods
     /// [`TCellOwner::wait_for_new`] or [`TCellOwner::try_new`] instead.
+    #[cfg(any(feature = "std", feature = "exclusion-set"))]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "exclusion-set"))))]
     pub fn new() -> Self {
         if let Some(owner) = TCellOwner::try_new() {
             owner
@@ -61,8 +87,22 @@ impl<Q: 'static> TCellOwner<Q> {
     /// Same as [`TCellOwner::new`], except if another `TCellOwner`
     /// of this type `Q` already exists, this returns `None` instead
     /// of panicking.
+    #[cfg(all(not(feature = "exclusion-set"), feature = "std"))]
     pub fn try_new() -> Option<Self> {
         if SINGLETON_CHECK.lock().unwrap().insert(TypeId::of::<Q>()) {
+            Some(Self { typ: PhantomData })
+        } else {
+            None
+        }
+    }
+
+    /// Same as [`TCellOwner::new`], except if another `TCellOwner`
+    /// of this type `Q` already exists, this returns `None` instead
+    /// of panicking.
+    #[cfg(feature = "exclusion-set")]
+    #[cfg_attr(docsrs, doc(cfg(any(feature = "std", feature = "exclusion-set"))))]
+    pub fn try_new() -> Option<Self> {
+        if SINGLETON_CHECK_SET.try_insert(TypeId::of::<Q>()) {
             Some(Self { typ: PhantomData })
         } else {
             None
@@ -81,6 +121,7 @@ impl<Q: 'static> TCellOwner<Q> {
     /// a `Mutex` or `RwLock` to control access.  This call is
     /// intended to help when several independent tests need to run
     /// which use the same marker type internally.
+    #[cfg(all(not(feature = "exclusion-set"), feature = "std"))]
     pub fn wait_for_new() -> Self {
         // Lock the HashSet mutex.
         let hashset_guard = SINGLETON_CHECK.lock().unwrap();
@@ -99,6 +140,28 @@ impl<Q: 'static> TCellOwner<Q> {
         // TypeId of Q from the HashSet, and notify all waiting threads.
         let inserted = hashset_guard.insert(TypeId::of::<Q>());
         assert!(inserted);
+        Self { typ: PhantomData }
+    }
+
+    /// Same as [`TCellOwner::new`], except if another `TCellOwner`
+    /// of this type `Q` already exists, this function blocks the thread
+    /// until that other instance is dropped.  This will of course deadlock
+    /// if that other instance is owned by the same thread.
+    ///
+    /// Note that owners are expected to be relatively long-lived.  If
+    /// you need to access cells associated with a given marker type
+    /// from several different threads, the most efficient pattern is
+    /// to have a single long-lived owner shared between threads, with
+    /// a `Mutex` or `RwLock` to control access.  This call is
+    /// intended to help when several independent tests need to run
+    /// which use the same marker type internally.
+    #[cfg(all(feature = "std", feature = "exclusion-set"))]
+    #[cfg_attr(
+        docsrs,
+        doc(cfg(any(feature = "std", all(feature = "exclusion-set", feature = "std"))))
+    )]
+    pub fn wait_for_new() -> Self {
+        SINGLETON_CHECK_SET.wait_to_insert(TypeId::of::<Q>());
         Self { typ: PhantomData }
     }
 
@@ -177,7 +240,6 @@ impl<Q: 'static> TCellOwner<Q> {
 ///
 /// [`TCellOwner`]: struct.TCellOwner.html
 #[repr(transparent)]
-#[cfg_attr(docsrs, doc(cfg(feature = "std")))]
 pub struct TCell<Q, T: ?Sized> {
     // Use Invariant<Q> for invariant parameter
     owner: PhantomData<Invariant<Q>>,
@@ -344,6 +406,7 @@ mod tests {
         let _ = rx.recv();
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn tcell_wait_for_new_in_100_threads() {
         use rand::Rng;
@@ -379,6 +442,7 @@ mod tests {
         assert_eq!(*owner.ro(&*cell_arc), 100);
     }
 
+    #[cfg(feature = "std")]
     #[test]
     fn tcell_wait_for_new_timeout() {
         fn assert_time_out<F>(d: std::time::Duration, f: F)


### PR DESCRIPTION
Adds optional no_std TCellOwner creation protected by exclusion-set.  TCell and TCellOwner (the types) are available in no_std code; the following methods are now cfg-guarded:

`TCellOwner::default` - (std || exclusion-set)
`TCellOwner::new` - (std || exclusion-set)
`TCellOwner::try_new` - (std || exclusion-set)
`TCellOwner::wait_for_new` - (std || (exclusion-set && std))

The behavior of the Drop impl for TCellOwner is now conditional on which features are enabled; I put the cfg on the method rather than having separate impls since it seemed more likely to catch mistakes, and avoid a situation where `std::mem::needs_drop` returns false for some downstream user when that's never actually possible.

Creating this initially as a draft PR since it seems likely you'll also want some adjustments to the testing infrastructure.