### PR TITLE
Add `rw_chain`

### DIFF
--- a/src/chain.rs
+++ b/src/chain.rs
@@ -1,0 +1,24 @@
+use alloc::vec::Vec;
+
+pub struct RwChain<'a, O> {
+    pub(crate) owner: &'a mut O,
+    pub(crate) addrs: Vec<usize>,
+}
+
+impl<'a, O> RwChain<'a, O> {
+    pub(crate) fn new(owner: &'a mut O) -> Self {
+        Self {
+            owner,
+            addrs: Vec::new(),
+        }
+    }
+
+    pub(crate) fn push_addr<C: ?Sized>(&mut self, cell: &C) {
+        self.addrs.push(cell as *const C as *const () as usize)
+    }
+
+    pub(crate) fn contains_addr<C: ?Sized>(&self, cell: &C) -> bool {
+        self.addrs
+            .contains(&(cell as *const C as *const () as usize))
+    }
+}

--- a/src/lcell.rs
+++ b/src/lcell.rs
@@ -161,17 +161,14 @@ impl<'id> LCellOwner<'id> {
 
 #[cfg(feature = "alloc")]
 impl<'a, 'id> RwChain<'a, LCellOwner<'id>> {
-    pub fn rw_chain<'b, T: ?Sized>(mut self, lc: &'b LCell<'id, T>) -> (&'b mut T, Self) {
+    #[allow(clippy::mut_from_ref)]
+    pub fn rw<T: ?Sized>(&mut self, lc: &'a LCell<'id, T>) -> &'a mut T {
         if self.contains_addr(lc) {
             panic!("Illegal to borrow same LCell twice with rw_chain()");
         }
         self.push_addr(lc);
 
-        (unsafe { &mut *lc.value.get() }, self)
-    }
-
-    pub fn rw<'b, T: ?Sized>(self, lc: &'b LCell<'id, T>) -> &'b mut T {
-        self.rw_chain(lc).0
+        unsafe { &mut *lc.value.get() }
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -368,13 +368,13 @@
 #[cfg(feature = "alloc")]
 extern crate alloc;
 
+#[cfg(feature = "alloc")]
+mod chain;
 mod lcell;
 mod qcell;
 mod tcell;
 #[cfg(feature = "std")]
 mod tlcell;
-#[cfg(feature = "alloc")]
-mod chain;
 
 pub mod doctest_lcell;
 #[cfg(feature = "generativity")]
@@ -411,6 +411,7 @@ pub extern crate generativity;
 // regarding "function pointers cannot appear in constant functions"
 struct Invariant<T>(fn(T) -> T);
 
+pub use crate::chain::RwChain;
 pub use crate::lcell::LCell;
 pub use crate::lcell::LCellOwner;
 pub use crate::qcell::QCell;
@@ -419,7 +420,6 @@ pub use crate::qcell::QCellOwnerPinned;
 pub use crate::qcell::QCellOwnerSeq;
 pub use crate::tcell::TCell;
 pub use crate::tcell::TCellOwner;
-pub use crate::chain::RwChain;
 
 #[cfg(feature = "alloc")]
 pub use crate::qcell::QCellOwner;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -373,6 +373,8 @@ mod qcell;
 mod tcell;
 #[cfg(feature = "std")]
 mod tlcell;
+#[cfg(feature = "alloc")]
+mod chain;
 
 pub mod doctest_lcell;
 #[cfg(feature = "generativity")]
@@ -417,6 +419,7 @@ pub use crate::qcell::QCellOwnerPinned;
 pub use crate::qcell::QCellOwnerSeq;
 pub use crate::tcell::TCell;
 pub use crate::tcell::TCellOwner;
+pub use crate::chain::RwChain;
 
 #[cfg(feature = "alloc")]
 pub use crate::qcell::QCellOwner;

--- a/src/qcell.rs
+++ b/src/qcell.rs
@@ -353,18 +353,15 @@ impl QCellOwner {
 
 #[cfg(feature = "alloc")]
 impl<'a> RwChain<'a, QCellOwner> {
-    pub fn rw_chain<T: ?Sized>(mut self, qc: &QCell<T>) -> (&mut T, Self) {
+    #[allow(clippy::mut_from_ref)]
+    pub fn rw<T: ?Sized>(&mut self, qc: &'a QCell<T>) -> &'a mut T {
         owner_check!(self.owner, qc);
         if self.contains_addr(qc) {
             not_distinct_panic();
         }
         self.push_addr(qc);
 
-        (unsafe { &mut *qc.value.get() }, self)
-    }
-
-    pub fn rw<T: ?Sized>(self, tc: &QCell<T>) -> &mut T {
-        self.rw_chain(tc).0
+        unsafe { &mut *qc.value.get() }
     }
 }
 

--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -134,17 +134,14 @@ impl<Q: 'static> TLCellOwner<Q> {
 
 #[cfg(feature = "alloc")]
 impl<'a, Q: 'static> RwChain<'a, TLCellOwner<Q>> {
-    pub fn rw_chain<T: ?Sized>(mut self, tc: &TLCell<Q, T>) -> (&mut T, Self) {
+    #[allow(clippy::mut_from_ref)]
+    pub fn rw<T: ?Sized>(&mut self, tc: &'a TLCell<Q, T>) -> &'a mut T {
         if self.contains_addr(tc) {
             panic!("Illegal to borrow same TLCell twice with rw_chain()");
         }
         self.push_addr(tc);
 
-        (unsafe { &mut *tc.value.get() }, self)
-    }
-
-    pub fn rw<T: ?Sized>(self, tc: &TLCell<Q, T>) -> &mut T {
-        self.rw_chain(tc).0
+        unsafe { &mut *tc.value.get() }
     }
 }
 


### PR DESCRIPTION
I basically implemented https://github.com/uazu/qcell/issues/46#issuecomment-1669598770 as well as I could.

The use of `Vec` makes this require the `alloc` feature; I could also imagine a similar API with a limit, using an array instead (it wouldn't even need to depend on `arrayvec` since the unused `usize`s could just be `0`, which isn't a valid address anyway), but I'll leave that for the future (if anyone turns out to need it).

This is somewhat barebones with regards to polish - I've only written tests for `TCell`. Should I duplicate these for all the other flavors?
Also, I haven't written any documentation yet. Let me know if you want to accept this, then I'll try to write some.