### PR TITLE
Add `TLCellOwner::try_new`

### DIFF
--- a/src/tlcell.rs
+++ b/src/tlcell.rs
@@ -256,6 +256,15 @@ mod tests {
     }
 
     #[test]
+    fn tlcell_singleton_try_new() {
+        struct Marker;
+        let owner1 = TLCellOwner::<Marker>::try_new();
+        assert!(owner1.is_some());
+        let owner2 = TLCellOwner::<Marker>::try_new();
+        assert!(owner2.is_none());
+    }
+
+    #[test]
     fn tlcell() {
         struct Marker;
         type ACellOwner = TLCellOwner<Marker>;


### PR DESCRIPTION
This PR adds a two functions to `TLCellOwner` which have the (almost) exact same behavior as the ones added for `TCell` in #15 :

- `TLCellOwner::try_new` checks if a `TLCellOwner` already exists, and returns None if it does.
- ~~`TLCellOwner::sleep_for_new` returns a future that can be awaited to create an instance of `TLCellOwner`~~.

~~Only an async wait makes sense in such thread local context (blocking the thread would block the thread which by definition owns the `TLCellOwner`). This needs to change the singleton check for `HashMap<TypeId, (bool, Vec<Waker>)>`, the bool says if the owner is currently existing and the `Vec<Waker>` stores tasks' wakers to wake one of them on each owner drop.~~

~~Let me know if you think the small overhead of the `HashMap` of `Vec`  instead of the `HashSet` on owner creation for all `TLCellOwner` users is not worth it (`try_new` is already enough to build such future with a specialized storage of the wakers).~~